### PR TITLE
Further improve code snippets

### DIFF
--- a/lib/docs-components/package.json
+++ b/lib/docs-components/package.json
@@ -27,7 +27,8 @@
     "@not-govuk/simple-table": "workspace:^0.1.0",
     "highlight.js": "^10.1.1",
     "prettier": "^2.0.5",
-    "prismjs": "^1.20.0"
+    "prismjs": "^1.20.0",
+    "prismjs-github": "^1.0.0"
   },
   "peerDependencies": {
     "@storybook/addon-docs": "^6.0.0-rc.11",

--- a/lib/docs-components/src/ReactPreview.scss
+++ b/lib/docs-components/src/ReactPreview.scss
@@ -55,6 +55,19 @@
       code {
         display: block;
         overflow-x: auto;
+
+        &[class*="language-"] {
+          color: inherit;
+          font-size: 14px;
+          font-size: 0.875rem;
+          line-height: 1.25;
+          tab-size: 2;
+
+          @media (min-width: 40.0625em) {
+            font-size: 16px;
+            font-size: 1rem;
+          }
+        }
       }
     }
   }

--- a/lib/docs-components/src/ReactPreview.tsx
+++ b/lib/docs-components/src/ReactPreview.tsx
@@ -19,7 +19,7 @@ import 'highlight.js/styles/github.css';
 import 'prismjs-github/scheme.css';
 
 const commonFormatOptions = {
-  printWidth: Math.round(68 * (4 / 5)),
+  printWidth: Math.round(60 * (9 / 10)),
   tabWidth: 2
 };
 
@@ -80,14 +80,14 @@ export const ReactPreview: FC<ReactPreviewProps> = ({ children, classBlock, clas
       { showing.html ? (
         <div className={classes('code')}>
           <pre>
-            <code dangerouslySetInnerHTML={{__html: html}} />
+            <code className="language-html" dangerouslySetInnerHTML={{__html: html}} />
           </pre>
         </div>
       ) : null}
       { showing.react && source ? (
         <div className={classes('code')}>
           <pre>
-            <code dangerouslySetInnerHTML={{__html: react}} />
+            <code className="language-jsx" dangerouslySetInnerHTML={{__html: react}} />
           </pre>
         </div>
       ) : null}

--- a/lib/docs-components/src/ReactPreview.tsx
+++ b/lib/docs-components/src/ReactPreview.tsx
@@ -16,7 +16,7 @@ import 'prismjs/components/prism-jsx.min';
 
 import './ReactPreview.scss';
 import 'highlight.js/styles/github.css';
-import 'prismjs/themes/prism.css';
+import 'prismjs-github/scheme.css';
 
 const commonFormatOptions = {
   printWidth: Math.round(68 * (4 / 5)),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,6 +382,7 @@ importers:
       highlight.js: 10.1.1
       prettier: 2.0.5
       prismjs: 1.20.0
+      prismjs-github: 1.0.0
     devDependencies:
       '@types/react': 16.9.43
       typescript: 3.9.7
@@ -393,6 +394,7 @@ importers:
       highlight.js: ^10.1.1
       prettier: ^2.0.5
       prismjs: ^1.20.0
+      prismjs-github: ^1.0.0
       typescript: ^3.9.2
   lib/engine:
     dependencies:
@@ -12922,6 +12924,10 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
+  /prismjs-github/1.0.0:
+    dev: false
+    resolution:
+      integrity: sha512-viBNgmYXllsWaLMvyiEC+g0hFagYd/r1Rvz2iYFt7tkx6Jv+PpQ5k93npV5sZD25Amu3Sl5lj8Mft0mUF+i/KA==
   /prismjs/1.17.1:
     dev: true
     optionalDependencies:


### PR DESCRIPTION
- Switches to a 'GitHub' theme for PrismSJ in order to improve constrast. (Probably addresses #35.)
- Applies class to `<code>` blocks in accordance with PrismJS
  documentation.
- Adds custom styling to prevent the theme from taking too much control.
- Reduces font-size of code snippet to improve aesthetics and to allow
  more code to be shown. (Tweaks line length accordingly.)