### PR TITLE
webpack-config: Simplify pipeline for CSS

### DIFF
--- a/lib/webpack-config/index.js
+++ b/lib/webpack-config/index.js
@@ -20,7 +20,6 @@ const ignoreLoader = require.resolve('ignore-loader');
 const mdxLoader = require.resolve('@mdx-js/loader');
 const resolveUrlLoader = require.resolve('resolve-url-loader');
 const sassLoader = require.resolve('sass-loader');
-const styleLoader = require.resolve('style-loader');
 
 const defaultOptions = {
   entry: './src/index.ts',
@@ -115,8 +114,6 @@ module.exports = function (options) {
   ];
 
   const cssLoaders = [
-    // Creates `style` nodes from JS strings
-    devMode && styleLoader,
     // Creates CSS asset files
     {
       loader: MiniCssExtractPlugin.loader,

--- a/lib/webpack-config/package.json
+++ b/lib/webpack-config/package.json
@@ -27,7 +27,6 @@
     "resolve-url-loader": "^3.1.1",
     "sass": "^1.26.10",
     "sass-loader": "^8.0.2",
-    "style-loader": "^1.2.1",
     "webpack-manifest-plugin": "^2.2.0",
     "webpack-node-externals": "^1.7.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,7 +521,6 @@ importers:
       resolve-url-loader: 3.1.1
       sass: 1.26.10
       sass-loader: 8.0.2_fibers@5.0.0+sass@1.26.10
-      style-loader: 1.2.1
       webpack-manifest-plugin: 2.2.0
       webpack-node-externals: 1.7.2
     optionalDependencies:
@@ -546,7 +545,6 @@ importers:
       resolve-url-loader: ^3.1.1
       sass: ^1.26.10
       sass-loader: ^8.0.2
-      style-loader: ^1.2.1
       webpack-manifest-plugin: ^2.2.0
       webpack-node-externals: ^1.7.2
   packages/components:
@@ -15185,17 +15183,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
-  /style-loader/1.2.1:
-    dependencies:
-      loader-utils: 2.0.0
-      schema-utils: 2.7.0
-    dev: false
-    engines:
-      node: '>= 8.9.0'
-    peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
-    resolution:
-      integrity: sha512-ByHSTQvHLkWE9Ir5+lGbVOXhxX10fbprhLvdg96wedFZb4NDekDPxVKv5Fwmio+QcMlkkNfuK+5W1peQ5CUhZg==
   /style-loader/1.2.1_webpack@4.43.0:
     dependencies:
       loader-utils: 2.0.0


### PR DESCRIPTION
It looks like we don't need style-loader even for HMR.

(In the apps HMR works just fine without it. I've not tested in
Storybook but I'd be surprised if that was any different.)