### PR TITLE
Fix typography page

### DIFF
--- a/lib/docs-components/src/ReactPreview.tsx
+++ b/lib/docs-components/src/ReactPreview.tsx
@@ -25,12 +25,20 @@ const formatHtml = (src: string): string => format(src, {
   plugins: [ parserHtml ],
   htmlWhitespaceSensitivity: 'ignore'
 });
-const formatJsx = (src: string): string => format(src, {
+const formatJsxUnsafe = (src: string): string => format(src, {
   ...commonFormatOptions,
   parser: 'babel',
   plugins: [ parserBabel ],
   arrowParens: 'avoid'
 }).replace(/;(\n)?$/, '$1');
+
+const formatJsx = (src: string): string => {
+  try {
+    return formatJsxUnsafe(src);
+  } catch (err) {
+    return formatJsxUnsafe('<>' + src + '</>');
+  }
+};
 
 const highlightHtml = (src: string): string => Prism.highlight(src, Prism.languages.html, 'html');
 const highlightJsx = (src: string): string => Prism.highlight(src, Prism.languages.jsx, 'jsx');

--- a/lib/docs-components/src/index.ts
+++ b/lib/docs-components/src/index.ts
@@ -1,4 +1,4 @@
-import { ComponentProps, ComponentType, FC, ReactElement, createElement as h } from 'react';
+import { ComponentProps, ComponentType, FC, Fragment, ReactElement, createElement as h } from 'react';
 import { id } from '@not-govuk/component-helpers';
 import { ReactPreview } from './ReactPreview';
 import { inStorybook } from './common';
@@ -55,15 +55,11 @@ export const Preview: FC<PreviewProps> = (props) => (
 export type StoryProps = ComponentProps<typeof _Story> & {
 };
 
-export const Story: FC<StoryProps> = (props) => {
-  const { children } = props;
-
-  return (
-    inStorybook
-      ? h(_Story, props)
-      : (children as ReactElement || null)
-  );
-};
+export const Story: FC<StoryProps> = ({ children, ...props }) => (
+  inStorybook
+    ? h(_Story, props)
+    : h(Fragment, {}, children)
+);
 
 export * from './DocsPage';
 export * from './Props';

--- a/styles/forms.stories.mdx
+++ b/styles/forms.stories.mdx
@@ -12,7 +12,7 @@ not intended for direct re-use. Instead, please see the components.
 
 <Preview>
   <Story name="Form group">
-    <div class="form-group">
+    <div className="form-group">
       This is a form group.
     </div>
   </Story>
@@ -23,7 +23,7 @@ not intended for direct re-use. Instead, please see the components.
 
 <Preview>
   <Story name="Form group error">
-    <div class="form-group error">
+    <div className="form-group error">
       This is a form group has an error.
     </div>
   </Story>
@@ -34,8 +34,8 @@ not intended for direct re-use. Instead, please see the components.
 
 <Preview>
   <Story name="Error message">
-    <div class="error">
-      <div class="message">
+    <div className="error">
+      <div className="message">
         This is an error message.
       </div>
     </div>
@@ -80,7 +80,7 @@ not intended for direct re-use. Instead, please see the components.
 
 <Preview>
   <Story name="Hint">
-    <span class="hint">
+    <span className="hint">
       This is a hint.
     </span>
   </Story>
@@ -101,7 +101,7 @@ not intended for direct re-use. Instead, please see the components.
 
 <Preview>
   <Story name="Input Text Error">
-    <div class="error">
+    <div className="error">
       <input name="example" type="text" />
     </div>
   </Story>


### PR DESCRIPTION
There was a bug on the typography page that was crashing the site. Specifically, we were not wrapping multiple elements in a Fragment, which is something that Babel demands.

In the long run, it might be nice to remove the Fragment afterwards although this might prove quite complicated to do.