### PR TITLE
Fix create package for npm init

### DIFF
--- a/lib/create/bin/create
+++ b/lib/create/bin/create
@@ -1,3 +1,4 @@
+#! /usr/bin/env node
 'use strict';
 
 const { execFileSync } = require('child_process');

--- a/lib/create/package.json
+++ b/lib/create/package.json
@@ -2,8 +2,8 @@
   "name": "@not-govuk/create",
   "version": "0.1.3",
   "description": "A project and prototype initialiser.",
-  "main": "bin/create.js",
-  "bin": "bin/create.js",
+  "main": "bin/create",
+  "bin": "bin/create",
   "files": [
     "/bin",
     "/plopfile.js",


### PR DESCRIPTION
Sets ap a shebang line and renames to remove the `.js` file extension.