### PR TITLE
create: Fix: Rename gitignore file

### DIFF
--- a/lib/create/plopfile.js
+++ b/lib/create/plopfile.js
@@ -112,7 +112,7 @@ module.exports = plop => {
       {
         type: 'copy',
         destination: rel('./.gitignore'),
-        source: 'skel/.gitignore'
+        source: 'skel/gitignore'
       },
       {
         type: 'copy',
@@ -160,6 +160,18 @@ module.exports = plop => {
         type: 'copy',
         destination: rel('./skel/'),
         source: 'skel/skel/'
+      },
+      {
+        type: 'shell',
+        command: 'mv -f skel/app/gitignore skel/app/.gitignore'
+      },
+      {
+        type: 'shell',
+        command: 'mv -f skel/component/gitignore skel/component/.gitignore'
+      },
+      {
+        type: 'shell',
+        command: 'mv -f skel/lib/gitignore skel/lib/.gitignore'
       },
       {
         type: 'copy',

--- a/lib/create/skel/.gitignore
+++ b/lib/create/skel/.gitignore
@@ -1,7 +1,1 @@
-*~
-*.log
-coverage/
-node_modules/
-packages/*/node_modules/
-package-lock.json
-storybook-static/
+gitignore

--- a/lib/create/skel/gitignore
+++ b/lib/create/skel/gitignore
@@ -1,0 +1,7 @@
+*~
+*.log
+coverage/
+node_modules/
+packages/*/node_modules/
+package-lock.json
+storybook-static/

--- a/lib/create/skel/skel/app/.gitignore
+++ b/lib/create/skel/skel/app/.gitignore
@@ -1,6 +1,1 @@
-.serverless/
-dist/
-node_modules/
-package-lock.json
-pnpm-lock.yaml
-tsconfig.tsbuildinfo
+gitignore

--- a/lib/create/skel/skel/app/gitignore
+++ b/lib/create/skel/skel/app/gitignore
@@ -1,0 +1,6 @@
+.serverless/
+dist/
+node_modules/
+package-lock.json
+pnpm-lock.yaml
+tsconfig.tsbuildinfo

--- a/lib/create/skel/skel/component/.gitignore
+++ b/lib/create/skel/skel/component/.gitignore
@@ -1,1 +1,1 @@
-../lib/.gitignore
+gitignore

--- a/lib/create/skel/skel/component/gitignore
+++ b/lib/create/skel/skel/component/gitignore
@@ -1,0 +1,1 @@
+../lib/.gitignore

--- a/lib/create/skel/skel/lib/.gitignore
+++ b/lib/create/skel/skel/lib/.gitignore
@@ -1,5 +1,1 @@
-dist/
-node_modules/
-package-lock.json
-pnpm-lock.yaml
-tsconfig.tsbuildinfo
+gitignore

--- a/lib/create/skel/skel/lib/gitignore
+++ b/lib/create/skel/skel/lib/gitignore
@@ -1,0 +1,5 @@
+dist/
+node_modules/
+package-lock.json
+pnpm-lock.yaml
+tsconfig.tsbuildinfo


### PR DESCRIPTION
`.gitignore` files have special significance so we need to rename it if
we want to use it simply for content.