### PR TITLE
plop-pack: Fix: Avoid .gitignore

### DIFF
--- a/lib/plop-pack/skel/component/gitignore
+++ b/lib/plop-pack/skel/component/gitignore
@@ -1,1 +1,5 @@
-../lib/.gitignore
+dist/
+node_modules/
+package-lock.json
+pnpm-lock.yaml
+tsconfig.tsbuildinfo

--- a/lib/plop-pack/src/generators/app.js
+++ b/lib/plop-pack/src/generators/app.js
@@ -40,7 +40,7 @@ module.exports = {
     {
       type: 'symlink',
       path: 'apps/{{{name}}}/.gitignore',
-      target: rel('.gitignore')
+      target: rel('gitignore')
     },
     {
       type: 'symlink',

--- a/lib/plop-pack/src/generators/component.js
+++ b/lib/plop-pack/src/generators/component.js
@@ -35,7 +35,7 @@ module.exports = {
     {
       type: 'symlink',
       path: 'components/{{{dashCase name}}}/.gitignore',
-      target: rel('.gitignore')
+      target: rel('gitignore')
     },
     {
       type: 'symlink',

--- a/lib/plop-pack/src/generators/lib.js
+++ b/lib/plop-pack/src/generators/lib.js
@@ -30,7 +30,7 @@ module.exports = {
     {
       type: 'symlink',
       path: 'lib/{{{name}}}/.gitignore',
-      target: rel('.gitignore')
+      target: rel('gitignore')
     },
     {
       type: 'symlink',


### PR DESCRIPTION
Renames `.gitignore` files to `gitignore` as NPM refuses to package
them.