### PR TITLE
CI: Break up Test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,8 @@ on:
   - pull_request
   - push
 jobs:
-  test:
-    name: Test
+  unit-test:
+    name: Unit test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -39,6 +39,40 @@ jobs:
 
       - name: Run unit tests
         run: npm test
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ '12' ]
+    steps:
+
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Cache NPM dependencies
+        uses: actions/cache@v2
+        env:
+          cache-hash: ${{ hashFiles('pnpm-lock.yaml') }}
+        with:
+          path: ~/.pnpm-store
+          key: pnpm-os_${{ runner.os }}-node_${{ matrix.node }}-lock_${{ env.cache-hash }}
+          restore-keys: |
+            pnpm-os_${{ runner.os }}-node_${{ matrix.node }}-
+            pnpm-os_${{ runner.os }}-
+            pnpm-
+
+      - name: Pull dependencies
+        uses: pnpm/action-setup@v1.2.0
+        with:
+          version: 5.4.0
+          run_install: true
 
       - name: Build everything
         run: npm run all:build


### PR DESCRIPTION
There's no need to run the build on different versions on Node.js.