### PR TITLE
plop-pack: Fix: Rely on Node's module resolution

### DIFF
--- a/lib-govuk/plop-pack/src/index.js
+++ b/lib-govuk/plop-pack/src/index.js
@@ -1,13 +1,14 @@
 'use strict';
 
 const { extendGenerator, relativePath } = require('@not-govuk/plop-pack-internal');
+const plopPackInternal = require.resolve('@not-govuk/plop-pack-internal');
 
 const rel = relativePath(__dirname, '..', 'skel');
 
 const plopFunction = plop => {
   const parent = '@not-govuk/plop-pack-internal';
 
-  plop.load('@not-govuk/plop-pack-internal', undefined, { actionTypes: true, generators: false, helpers: true, partials: false });
+  plop.load(plopPackInternal, undefined, { actionTypes: true, generators: false, helpers: true, partials: false });
 
   plop.setGenerator(
     'app',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19189,7 +19189,7 @@ packages:
       '@webassemblyjs/wasm-parser': 1.9.0
       acorn: 6.4.1
       ajv: 6.12.3
-      ajv-keywords: 3.5.1_ajv@6.12.3
+      ajv-keywords: 3.5.2_ajv@6.12.3
       chrome-trace-event: 1.0.2
       enhanced-resolve: 4.3.0
       eslint-scope: 4.0.3


### PR DESCRIPTION
This is a workaround due to a bug in node-plop. It can be reverted if
and when https://github.com/plopjs/node-plop/pull/180 is merged.