### PR TITLE
CI: Speed up push to Chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -43,3 +43,4 @@ jobs:
           buildScriptName: 'build:storybook'
           autoAcceptChanges: master
           exitZeroOnChanges: true
+          exitOnceUploaded: true


### PR DESCRIPTION
The chromatic tool seems to suggest setting this flag in CI in order to
speed up the job. It sounds like the remaining work is done on the
Chromatic servers and so there's no point in repeating it here.