### PR TITLE
plop-pack: Fix: Second workaround

### DIFF
--- a/lib-govuk/plop-pack/src/index.js
+++ b/lib-govuk/plop-pack/src/index.js
@@ -6,7 +6,7 @@ const plopPackInternal = require.resolve('@not-govuk/plop-pack-internal');
 const rel = relativePath(__dirname, '..', 'skel');
 
 const plopFunction = plop => {
-  const parent = '@not-govuk/plop-pack-internal';
+  const parent = plopPackInternal;
 
   plop.load(plopPackInternal, undefined, { actionTypes: true, generators: false, helpers: true, partials: false });
 


### PR DESCRIPTION
This is another workaround for the bug in node-plop. Like the other one,
it can be reverted if and when
https://github.com/plopjs/node-plop/pull/180 is merged.