### PR TITLE
Add GraphQL support via Apollo Client

### DIFF
--- a/apps/govuk-docs/src/server/template.tsx
+++ b/apps/govuk-docs/src/server/template.tsx
@@ -18,7 +18,7 @@ export const Template: FC<TemplateProps> = props => {
             <link key={v} href={`${props.assetsPath}${v}`} rel="stylesheet" />
           )
         )}
-        {props && <script dangerouslySetInnerHTML={{__html: `window.hydrationId = '${props.rootId}'; window.hydrationProps = ${JSON.stringify(props.appProps).replace(/</g, '\\u003c')};`}} />}
+        {props && <script dangerouslySetInnerHTML={{__html: `window.hydrationId = '${props.rootId}'; window.hydrationProps = ${JSON.stringify(props.appProps)?.replace(/</g, '\\u003c')}; window.hydrationData = ${JSON.stringify(props.data)?.replace(/</g, '\\u003c')};`}} />}
       </head>
       <body>
         <div id={props.rootId} dangerouslySetInnerHTML={{__html: props.appRender as string}} />

--- a/apps/govuk-template/package.json
+++ b/apps/govuk-template/package.json
@@ -16,6 +16,8 @@
   "author": "Daniel A.C. Martin <npm@daniel-martin.co.uk> (http://daniel-martin.co.uk/)",
   "license": "MIT",
   "devDependencies": {
+    "@apollo/client": "^3.2.3",
+    "@graphql-tools/schema": "^7.0.0",
     "@not-govuk/app-composer": "workspace:^0.1.0",
     "@not-govuk/client-renderer": "workspace:^0.1.0",
     "@not-govuk/components": "workspace:^0.1.0",
@@ -29,6 +31,7 @@
     "@types/react-router-dom": "^5.1.5",
     "@types/webpack-env": "^1.15.2",
     "bunyan": "^1.8.12",
+    "graphql": "^15.3.0",
     "node-hot-loader": "^1.19.0",
     "react": "^16.9.55",
     "react-dom": "^16.9.55",

--- a/apps/govuk-template/src/common/pages/graphql-test.tsx
+++ b/apps/govuk-template/src/common/pages/graphql-test.tsx
@@ -1,0 +1,39 @@
+import { useQuery, gql } from '@apollo/client';
+import { FC, Fragment, createElement as h } from 'react';
+import { PageProps } from '@not-govuk/app-composer';
+
+const books = gql`
+  { books {
+    title
+    author
+  } }
+`;
+
+const Page: FC<PageProps> = () => {
+  const { loading, error, data } = useQuery(books);
+  // console.log('loading:');
+  // console.log(loading);
+  // console.log('error:');
+  // console.log(error);
+  // console.log('data:');
+  // console.log(data);
+
+  return (
+    <Fragment>
+      <h1>GraphQL</h1>
+      <h2>Books</h2>
+      <ul>
+        { data?.books?.map(
+            ({ author, title }, i) => (
+              <li key={i}>
+                <strong>{title}</strong> {author}
+              </li>
+            )
+        ) }
+      </ul>
+    </Fragment>
+  );
+};
+
+export default Page;
+export const title = 'GraphQL spike';

--- a/apps/govuk-template/src/common/pages/two.tsx
+++ b/apps/govuk-template/src/common/pages/two.tsx
@@ -1,7 +1,0 @@
-import { FC, createElement as h } from 'react';
-import { PageProps } from '@not-govuk/app-composer';
-
-const Page: FC<PageProps> = () => <h1>Two</h1>;
-
-export default Page;
-export const title = 'Two';

--- a/apps/govuk-template/src/server/index.ts
+++ b/apps/govuk-template/src/server/index.ts
@@ -7,6 +7,37 @@ import ErrorPage from '../common/error-page';
 import PageWrap from '../common/page-wrap';
 import pageLoader from '../common/page-loader';
 
+import { makeExecutableSchema } from '@graphql-tools/schema';
+
+// Some fake data
+const books = [
+  {
+    title: "Harry Potter and the Sorcerer's stone",
+    author: 'J.K. Rowling',
+  },
+  {
+    title: 'Jurassic Park',
+    author: 'Michael Crichton',
+  },
+];
+
+// The GraphQL schema in string form
+const typeDefs = `
+type Query { books: [Book] }
+type Book { title: String, author: String }
+`;
+
+// The resolvers
+const resolvers = {
+  Query: { books: () => books },
+};
+
+// Put together a schema
+const graphQLSchema = makeExecutableSchema({
+  typeDefs,
+  resolvers,
+});
+
 const setup = () => {
   const assets = (
     config.env === NodeEnv.Development && !config.ssrOnly
@@ -39,6 +70,9 @@ const startApp = () => stage1.then(
     ErrorPage,
     PageWrap,
     Template,
+    graphQL: {
+      schema: graphQLSchema
+    },
     pageLoader
   })
 );

--- a/apps/govuk-template/src/server/template.tsx
+++ b/apps/govuk-template/src/server/template.tsx
@@ -18,7 +18,7 @@ export const Template: FC<TemplateProps> = props => {
             <link key={v} href={`${props.assetsPath}${v}`} rel="stylesheet" />
           )
         )}
-        {props && <script dangerouslySetInnerHTML={{__html: `window.hydrationId = '${props.rootId}'; window.hydrationProps = ${JSON.stringify(props.appProps).replace(/</g, '\\u003c')};`}} />}
+        {props && <script dangerouslySetInnerHTML={{__html: `window.hydrationId = '${props.rootId}'; window.hydrationProps = ${JSON.stringify(props.appProps)?.replace(/</g, '\\u003c')}; window.hydrationData = ${JSON.stringify(props.data)?.replace(/</g, '\\u003c')};`}} />}
       </head>
       <body>
         <div id={props.rootId} dangerouslySetInnerHTML={{__html: props.appRender as string}} />

--- a/lib-govuk/plop-pack/skel/app/src/server/template.tsx
+++ b/lib-govuk/plop-pack/skel/app/src/server/template.tsx
@@ -18,7 +18,7 @@ export const Template: FC<TemplateProps> = props => {
             <link key={v} href={`${props.assetsPath}${v}`} rel="stylesheet" />
           )
         )}
-        {props && <script dangerouslySetInnerHTML={{__html: `window.hydrationId = '${props.rootId}'; window.hydrationProps = ${JSON.stringify(props.appProps).replace(/</g, '\\u003c')};`}} />}
+        {props && <script dangerouslySetInnerHTML={{__html: `window.hydrationId = '${props.rootId}'; window.hydrationProps = ${JSON.stringify(props.appProps).replace(/</g, '\\u003c')}; window.hydrationData = ${JSON.stringify(props.data)?.replace(/</g, '\\u003c')};`}} />}
       </head>
       <body>
         <div id={props.rootId} dangerouslySetInnerHTML={{__html: props.appRender as string}} />

--- a/lib/app-composer/package.json
+++ b/lib/app-composer/package.json
@@ -31,6 +31,7 @@
     "@types/react": "^16.9.55",
     "@types/react-router": "^5.1.7",
     "@types/react-router-dom": "^5.1.5",
+    "graphql": "^15.4.0",
     "typescript": "^3.9.2"
   }
 }

--- a/lib/app-composer/package.json
+++ b/lib/app-composer/package.json
@@ -22,6 +22,7 @@
     "@not-govuk/route-utils": "workspace:^0.1.0"
   },
   "peerDependencies": {
+    "@apollo/client": "^3.2.3",
     "react": "^16.9.35",
     "react-router": "^5.1.7",
     "react-router-dom": "^5.1.5"

--- a/lib/app-composer/src/index.ts
+++ b/lib/app-composer/src/index.ts
@@ -1,3 +1,4 @@
+import { GraphQLSchema } from 'graphql';
 import { ApolloClient, ApolloProvider, InMemoryCache, createHttpLink } from '@apollo/client';
 import { SchemaLink } from '@apollo/client/link/schema';
 import { ComponentType, Fragment, Suspense, createElement as h, lazy } from 'react';
@@ -79,7 +80,7 @@ type ComposeOptionsCommon = {
 
 type ComposeOptionsSSR = ComposeOptionsCommon & {
   graphQL?: {
-    schema: object
+    schema: GraphQLSchema
   }
   routerProps: StaticRouterProps
 };

--- a/lib/app-composer/src/index.ts
+++ b/lib/app-composer/src/index.ts
@@ -1,3 +1,5 @@
+import { ApolloClient, ApolloProvider, InMemoryCache, createHttpLink } from '@apollo/client';
+import { SchemaLink } from '@apollo/client/link/schema';
 import { ComponentType, Fragment, Suspense, createElement as h, lazy } from 'react';
 import { StaticRouter, StaticRouterProps, Switch } from 'react-router';
 import { BrowserRouter, BrowserRouterProps } from 'react-router-dom';
@@ -38,7 +40,9 @@ export type ApplicationPropsSSR = ApplicationPropsCommon & {
 export type ApplicationProps = ApplicationPropsCSR | ApplicationPropsSSR;
 
 type ApplicationCSR = ComponentType<ApplicationPropsCSR>;
-type ApplicationSSR = ComponentType<ApplicationPropsSSR>;
+type ApplicationSSR = ComponentType<ApplicationPropsSSR> & {
+  extractDataCache: () => object
+};
 export type Application = ComponentType<ApplicationProps>;
 
 export type PageProps = RouteComponentProps & {
@@ -70,14 +74,21 @@ type ComposeOptionsCommon = {
   AppWrap: Application
   ErrorPage: ErrorPage
   PageWrap: Page
+  data: object
 };
 
 type ComposeOptionsSSR = ComposeOptionsCommon & {
+  graphQL?: {
+    schema: object
+  }
   routerProps: StaticRouterProps
 };
 
 type ComposeOptionsCSR = ComposeOptionsCommon & {
   LoadingPage: Page
+  graphQL?: {
+    endpoint: string,
+  }
   pageLoader: PageLoader
   routerProps: BrowserRouterProps
 };
@@ -89,86 +100,123 @@ type Compose = {
   (options: ComposeOptionsSSR): ApplicationSSR;
 };
 
-export const compose: Compose = options => props => {
+type DataProviderProps = {
+  client?: ApolloClient<any>
+};
+
+export const compose: Compose = options => {
   const Router = (
     "context" in options.routerProps
       ? StaticRouter
       : BrowserRouter
-  );
-  const routes = props
-    .pages
-    .map(e => ({
-      Component: (
-        "pageLoader" in options
-          ? lazy(() => options.pageLoader(e.src))
-          : e.Component
-      ),
-      href: decodeURI(e.href),
-      title: e.title
-    }));
-  const pageProps = { routes };
-  const withPageWrap = Component => props => (
-    h(
-      options.PageWrap, pageProps,
-      h(Component, props)
-    )
   );
   const SuspenseOrFragment = (
     "LoadingPage" in options
       ? Suspense
       : Fragment
   );
-  const suspenseProps = (
-    "LoadingPage" in options
-      ? { fallback: h(withRouter(withPageWrap(options.LoadingPage))) }
+  const client = (
+    options.graphQL
+      ? (
+        new ApolloClient({
+          cache: new InMemoryCache().restore(options.data),
+          link: (
+            options.graphQL.schema
+              ? new SchemaLink({ schema: options.graphQL.schema })
+              : createHttpLink(options.graphQL.endpoint)
+          )
+        })
+      )
       : undefined
   );
-  const PageError = withPageWrap(options.ErrorPage);
-
-  const switchOrError = (
-    props.err
-      ? h(
-        withRouter(PageError),
-        {
-          internal: String(props.err.statusCode).startsWith('5'),
-          title: props.err.title,
-          message: props.err.message
-        })
-      : h(
-        Switch, {},
-        [
-          ...routes.map((v, i) => h(
-            Route,
-            {
-              component: withPageWrap(v.Component),
-              exact: true,
-              key: i,
-              path: v.href
-            }
-          )),
-          h(Route, {
-            component: props => h(
-              PageError,
-              {
-                ...props,
-                internal: false,
-                title: 'Page not found',
-                message: `${props.location.pathname} does not exist.`
-              }
-            ),
-            key: 'catch-all'
-          })
-        ]
-      )
+  const DataProvider: ComponentType<DataProviderProps> = ({ children, client = undefined }) => (
+    client
+      ? h(ApolloProvider, {
+        client,
+        children
+      })
+      : h(Fragment, {}, children)
   );
+  const extractDataCache = () => client && client.extract();
 
-  return h(
-    options.AppWrap, props,
-    h(Router, options.routerProps,
+  const App =  props => {
+    const routes = props
+      .pages
+      .map(e => ({
+        Component: (
+          "pageLoader" in options
+            ? lazy(() => options.pageLoader(e.src))
+            : e.Component
+        ),
+        href: decodeURI(e.href),
+        title: e.title
+      }));
+    const pageProps = { routes };
+    const withPageWrap = Component => props => (
+      h(
+        options.PageWrap, pageProps,
+        h(Component, props)
+      )
+    );
+    const suspenseProps = (
+      "LoadingPage" in options
+        ? { fallback: h(withRouter(withPageWrap(options.LoadingPage))) }
+        : undefined
+    );
+    const PageError = withPageWrap(options.ErrorPage);
+
+    const switchOrError = (
+      props.err
+        ? h(
+          withRouter(PageError),
+          {
+            internal: String(props.err.statusCode).startsWith('5'),
+            title: props.err.title,
+            message: props.err.message
+          })
+        : h(
+          Switch, {},
+          [
+              ...routes.map((v, i) => h(
+                Route,
+                {
+                  component: withPageWrap(v.Component),
+                  exact: true,
+                  key: i,
+                  path: v.href
+                }
+              )),
+              h(Route, {
+                component: props => h(
+                  PageError,
+                  {
+                    ...props,
+                    internal: false,
+                    title: 'Page not found',
+                    message: `${props.location.pathname} does not exist.`
+                  }
+                ),
+                key: 'catch-all'
+              })
+          ]
+        )
+    );
+
+    const router = h(
+      Router, options.routerProps,
       h(
         SuspenseOrFragment, suspenseProps,
         switchOrError
       )
-     )
-  );
+    );
+
+    return h(
+      options.AppWrap, props,
+      h(DataProvider, { client }, router)
+    );
+  };
+
+  return Object.assign(App, { extractDataCache });
 };
+
+export { renderToStringWithData } from '@apollo/client/react/ssr';

--- a/lib/client-renderer/src/index.ts
+++ b/lib/client-renderer/src/index.ts
@@ -4,6 +4,7 @@ import { ApplicationProps, ApplicationPropsCSR, ErrorPageProps, PageProps, PageL
 
 export const hydrateOrRender = (AppWrap: ComponentType<ApplicationProps>, PageWrap: ComponentType<PageProps>, ErrorPage: ComponentType<ErrorPageProps>, LoadingPage: ComponentType<PageProps>, pageLoader: PageLoader): void => {
   interface IWindowWithHydration extends Window {
+    hydrationData?: object
     hydrationId?: string
     hydrationProps?: ApplicationPropsCSR
   };
@@ -16,6 +17,10 @@ export const hydrateOrRender = (AppWrap: ComponentType<ApplicationProps>, PageWr
       ErrorPage,
       LoadingPage,
       PageWrap,
+      data: windowWithProps.hydrationData,
+      graphQL: {
+        endpoint: '/graphql'
+      },
       pageLoader,
       routerProps
     }),

--- a/lib/engine/package.json
+++ b/lib/engine/package.json
@@ -39,6 +39,7 @@
     "@types/webpack": "^4.41.12",
     "@types/webpack-dev-middleware": "^3.7.0",
     "@types/webpack-hot-middleware": "^2.25.2",
+    "graphql": "^15.4.0",
     "typescript": "^3.9.2"
   }
 }

--- a/lib/engine/package.json
+++ b/lib/engine/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@not-govuk/restify": "workspace:^0.1.0",
     "@not-govuk/server-renderer": "workspace:^0.1.0",
+    "apollo-server-restify": "^1.3.6",
     "etag": "^1.8.1",
     "http-proxy-middleware": "^1.0.5",
     "serverless-http": "^2.4.1"

--- a/lib/engine/src/index.ts
+++ b/lib/engine/src/index.ts
@@ -90,6 +90,7 @@ export const engine = async (options1: EngineStage1Options) => {
   if (webpack) {
     // Set up extra Restify instance for proxy
     const httpd = restify.createServer({
+      bodyParser: false,
       name: `${options1.name}-asset-proxy`
     });
     const proxyMiddleware = createProxyMiddleware({

--- a/lib/engine/src/index.ts
+++ b/lib/engine/src/index.ts
@@ -1,4 +1,5 @@
 import { graphqlRestify, graphiqlRestify } from 'apollo-server-restify';
+import { GraphQLSchema } from 'graphql';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import { ComponentType } from 'react';
 import serverless from 'serverless-http';
@@ -57,7 +58,7 @@ export type EngineStage2Options = {
   Template: ComponentType<TemplateProps>
   apis?: Api[]
   graphQL?: {
-    schema: object
+    schema: GraphQLSchema
   }
   pageLoader: PageLoader
 };

--- a/lib/engine/src/lib/pages.ts
+++ b/lib/engine/src/lib/pages.ts
@@ -89,8 +89,7 @@ export const gatherPages = (pageLoader: PageLoader): Promise<PageInfoSSR[]> => (
 );
 
 const pageMiddleware = (title: string) => (req, res, next) => {
-  res.renderApp(200, title);
-  next();
+  res.renderApp(200, title).finally(next);
 };
 
 export const pageRoutes = (pages: PageInfoSSR[]) => {

--- a/lib/plop-pack/skel/app/src/server/template.tsx
+++ b/lib/plop-pack/skel/app/src/server/template.tsx
@@ -14,7 +14,7 @@ export const Template: FC<TemplateProps> = props => {
             <link key={v} href={`${props.assetsPath}${v}`} rel="stylesheet" />
           )
         )}
-        {props && <script dangerouslySetInnerHTML={{__html: `window.hydrationId = '${props.rootId}'; window.hydrationProps = ${JSON.stringify(props.appProps).replace(/</g, '\\u003c')};`}} />}
+        {props && <script dangerouslySetInnerHTML={{__html: `window.hydrationId = '${props.rootId}'; window.hydrationProps = ${JSON.stringify(props.appProps).replace(/</g, '\\u003c')}; window.hydrationData = ${JSON.stringify(props.data)?.replace(/</g, '\\u003c')};`}} />}
       </head>
       <body>
         <div id={props.rootId} dangerouslySetInnerHTML={{__html: props.appRender as string}} />

--- a/lib/restify/src/index.ts
+++ b/lib/restify/src/index.ts
@@ -9,7 +9,7 @@ import { ILoggerOptions, logger } from './lib/logger';
 import { installServeAPI } from './lib/serve-api';
 
 export type ServerOptions = _ServerOptions & {
-  bodyParser?: plugins.BodyParserOptions
+  bodyParser?: plugins.BodyParserOptions | false
   grace?: number
   liveness?: string
   logger?: ILoggerOptions
@@ -73,7 +73,7 @@ export const createServer = (options: ServerOptions ) => {
   httpd.pre(htmlByDefault(httpd));
 
   httpd.use(restify.plugins.acceptParser(httpd.acceptable.filter(v => acceptable.includes(v))));
-  httpd.use(restify.plugins.bodyParser(Object.assign({ mapParams: false }, options.bodyParser)));
+  (options.bodyParser !== false) && httpd.use(restify.plugins.bodyParser(Object.assign({ mapParams: false }, options.bodyParser)));
   httpd.use(restify.plugins.queryParser(Object.assign({ mapParams: false }, options.queryParser)));
   httpd.use(restify.plugins.requestLogger(options.requestLogger));
   httpd.use(restify.plugins.fullResponse());

--- a/lib/server-renderer/package.json
+++ b/lib/server-renderer/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^13.13.4",
     "@types/react": "^16.9.55",
     "@types/react-dom": "^16.9.8",
+    "graphql": "^15.4.0",
     "typescript": "^3.9.2"
   }
 }

--- a/lib/server-renderer/src/index.ts
+++ b/lib/server-renderer/src/index.ts
@@ -1,7 +1,7 @@
 import { ComponentType, createElement as h } from 'react';
 import { renderToStaticMarkup, renderToString } from 'react-dom/server';
 import { html as beautifyHtml } from 'js-beautify';
-import { ApplicationProps, ApplicationPropsSSR, ErrorPageProps, PageProps, PageInfoSSR, compose } from '@not-govuk/app-composer';
+import { ApplicationProps, ApplicationPropsSSR, ErrorPageProps, PageProps, PageInfoSSR, compose, renderToStringWithData } from '@not-govuk/app-composer';
 
 const statusToTitle = {
   400: 'Bad request',
@@ -29,6 +29,7 @@ export type TemplateProps = {
   appRender: string
   assetsPath: string
   charSet: string
+  data: object
   rootId: string
   scripts: string[]
   stylesheets: string[]
@@ -39,6 +40,9 @@ export type Template = ComponentType<TemplateProps>;
 export type RendererOptions = {
   assetsPath: string
   entrypoints?: object
+  graphQL?: {
+    schema: object
+  }
   pages: PageInfoSSR[]
   rootId: string,
   ssrOnly: boolean
@@ -55,7 +59,8 @@ const contentTypeToCharSet = (contentType: string): string => {
 };
 
 export const reactRenderer = (AppWrap: ComponentType<ApplicationProps>, PageWrap: ComponentType<PageProps>, ErrorPage: ComponentType<ErrorPageProps>, Template: Template, options: RendererOptions) => {
-  const formatHTML = (req, res, body) => {
+  const createApp = (req, res, body, charSet) => {
+    const data = {}
     const routerProps = {
       location: req.url,
       context: {
@@ -79,65 +84,100 @@ export const reactRenderer = (AppWrap: ComponentType<ApplicationProps>, PageWrap
       pages: options.pages,
       ...reqProps
     };
-    const appRender = renderToString(h(
-      compose({
+    const App = compose({
         AppWrap,
         ErrorPage,
         PageWrap,
-        routerProps
-      }),
-      appProps
-    ));
-    const assetsByChunkName = res?.locals?.webpack?.devMiddleware.stats.toJson().assetsByChunkName || // v4 dev-middleware
-      res?.locals?.webpackStats?.toJson().assetsByChunkName || // v3 dev-middleware
-      options.entrypoints; // pre-built assets
-    const assets: string[] = (
-      Object.values(assetsByChunkName)
-        .flat()
-        .map(v => String(v))
-    );
-    const fullTemplateProps = {
-      appProps,
-      appRender,
-      assetsPath: options.assetsPath,
-      charSet: contentTypeToCharSet(res.header('Content-Type')),
-      rootId: options.rootId,
-      scripts: (
-        options.ssrOnly
-          ? undefined
-          : assets.filter(v => v.endsWith('.js'))
-      ),
-      stylesheets: assets.filter(v => v.endsWith('.css'))
+        graphQL: options.graphQL && {
+          schema: options.graphQL.schema
+        },
+        routerProps,
+        data
+    });
+    const app = h(App, appProps)
+
+    const render = (): Promise<string> => renderToStringWithData(app);
+
+    const renderToHtml = (appRender?: string): string => {
+      appRender = appRender || renderToString(app);
+
+      const assetsByChunkName = res?.locals?.webpack?.devMiddleware.stats.toJson().assetsByChunkName || // v4 dev-middleware
+        res?.locals?.webpackStats?.toJson().assetsByChunkName || // v3 dev-middleware
+        options.entrypoints; // pre-built assets
+      const assets: string[] = (
+        Object.values(assetsByChunkName)
+          .flat()
+          .map(v => String(v))
+      );
+      const fullTemplateProps = {
+        appProps,
+        appRender,
+        assetsPath: options.assetsPath,
+        charSet: charSet,
+        data: App.extractDataCache(),
+        rootId: options.rootId,
+        scripts: (
+          options.ssrOnly
+            ? undefined
+            : assets.filter(v => v.endsWith('.js'))
+        ),
+        stylesheets: assets.filter(v => v.endsWith('.css'))
+      };
+
+      return beautifyHtml(
+        renderToStaticMarkup(h(Template, fullTemplateProps)),
+        {
+          'indent_with_tabs': true
+        }
+      );
     };
 
-    const html = beautifyHtml(
-      renderToStaticMarkup(
-        h(Template, fullTemplateProps)
-      ),
-      {
-        'indent_with_tabs': true
-      }
-    );
-
-    res.setHeader('Content-Length', Buffer.byteLength(html));
-
-    return html;
+    return {
+      render,
+      renderToHtml
+    };
   };
 
-  const renderApp = function(code, body, headers) {
+  const formatHTML = (req, res, body) => {
+    if (!res.html) {
+      const app = createApp(req, res, body, contentTypeToCharSet(res.header('Content-Type')));
+      res.html = app.renderToHtml();
+    }
+
+    res.setHeader('Content-Length', Buffer.byteLength(res.html));
+
+    return res.html;
+  };
+
+  const renderApp = req => function(code, body, headers): Promise<void> {
+    const res = this;
+    const charSet = 'UTF-8';
+
     if (typeof code !== 'number') {
       headers = body;
       body = code;
       code = 200;
     }
 
-    this.charSet('UTF-8');
-    this.contentType = 'text/html';
-    this.send(code, body || true, headers);
+    res.statusCode = code;
+    res.charSet(charSet);
+    res.contentType = 'text/html';
+
+    const app = createApp(req, res, body, charSet);
+    const promise = (
+      options.graphQL
+        ? app.render()
+        : Promise.resolve('')
+    );
+
+    return promise.then(renderedApp => {
+      res.html = app.renderToHtml(renderedApp)
+      res.send(code, body || true, headers);
+    });
   };
 
   const renderer = (req, res, next) => {
-    res.renderApp = renderApp;
+    res.renderApp = renderApp(req);
     next();
   }
 

--- a/lib/server-renderer/src/index.ts
+++ b/lib/server-renderer/src/index.ts
@@ -1,3 +1,4 @@
+import { GraphQLSchema } from 'graphql';
 import { ComponentType, createElement as h } from 'react';
 import { renderToStaticMarkup, renderToString } from 'react-dom/server';
 import { html as beautifyHtml } from 'js-beautify';
@@ -41,7 +42,7 @@ export type RendererOptions = {
   assetsPath: string
   entrypoints?: object
   graphQL?: {
-    schema: object
+    schema: GraphQLSchema
   }
   pages: PageInfoSSR[]
   rootId: string,

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "homepage": "https://github.com/daniel-ac-martin/NotGovUK#readme",
   "devDependencies": {
+    "@apollo/client": "^3.2.3",
     "@babel/core": "^7.11.4",
     "@babel/plugin-proposal-export-namespace-from": "^7.10.4",
     "@babel/preset-env": "^7.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 importers:
   .:
     devDependencies:
+      '@apollo/client': 3.2.5_react@16.14.0
       '@babel/core': 7.11.4
       '@babel/plugin-proposal-export-namespace-from': 7.10.4_@babel+core@7.11.4
       '@babel/preset-env': 7.11.0_@babel+core@7.11.4
@@ -41,6 +42,7 @@ importers:
       webpack-dev-middleware: 3.7.2_webpack@4.43.0
       webpack-hot-middleware: 2.25.0
     specifiers:
+      '@apollo/client': ^3.2.3
       '@babel/core': ^7.11.4
       '@babel/plugin-proposal-export-namespace-from': ^7.10.4
       '@babel/preset-env': ^7.11.0
@@ -135,6 +137,8 @@ importers:
       webpack-hot-middleware: ^2.25.0
   apps/govuk-template:
     devDependencies:
+      '@apollo/client': 3.2.5_graphql@15.4.0+react@16.14.0
+      '@graphql-tools/schema': 7.0.0_graphql@15.4.0
       '@not-govuk/app-composer': 'link:../../lib/app-composer'
       '@not-govuk/client-renderer': 'link:../../lib/client-renderer'
       '@not-govuk/components': 'link:../../packages/components'
@@ -148,6 +152,7 @@ importers:
       '@types/react-router-dom': 5.1.5
       '@types/webpack-env': 1.15.2
       bunyan: 1.8.14
+      graphql: 15.4.0
       node-hot-loader: 1.20.0_webpack@4.43.0
       react: 16.14.0
       react-dom: 16.14.0_react@16.14.0
@@ -160,6 +165,8 @@ importers:
       webpack-dev-middleware: 3.7.2_webpack@4.43.0
       webpack-hot-middleware: 2.25.0
     specifiers:
+      '@apollo/client': ^3.2.3
+      '@graphql-tools/schema': ^7.0.0
       '@not-govuk/app-composer': 'workspace:^0.1.0'
       '@not-govuk/client-renderer': 'workspace:^0.1.0'
       '@not-govuk/components': 'workspace:^0.1.0'
@@ -173,6 +180,7 @@ importers:
       '@types/react-router-dom': ^5.1.5
       '@types/webpack-env': ^1.15.2
       bunyan: ^1.8.12
+      graphql: ^15.3.0
       node-hot-loader: ^1.19.0
       react: ^16.9.55
       react-dom: ^16.9.55
@@ -566,12 +574,14 @@ importers:
       '@types/react': 16.9.55
       '@types/react-router': 5.1.8
       '@types/react-router-dom': 5.1.5
+      graphql: 15.4.0
       typescript: 3.9.7
     specifiers:
       '@not-govuk/route-utils': 'workspace:^0.1.0'
       '@types/react': ^16.9.55
       '@types/react-router': ^5.1.7
       '@types/react-router-dom': ^5.1.5
+      graphql: ^15.4.0
       typescript: ^3.9.2
   lib/client-renderer:
     dependencies:
@@ -736,6 +746,7 @@ importers:
     dependencies:
       '@not-govuk/restify': 'link:../restify'
       '@not-govuk/server-renderer': 'link:../server-renderer'
+      apollo-server-restify: 1.3.6_graphql@15.4.0
       etag: 1.8.1
       http-proxy-middleware: 1.0.5
       serverless-http: 2.5.0
@@ -747,6 +758,7 @@ importers:
       '@types/webpack': 4.41.21
       '@types/webpack-dev-middleware': 3.7.1
       '@types/webpack-hot-middleware': 2.25.3
+      graphql: 15.4.0
       typescript: 3.9.7
     specifiers:
       '@not-govuk/app-composer': 'workspace:^0.1.0'
@@ -758,7 +770,9 @@ importers:
       '@types/webpack': ^4.41.12
       '@types/webpack-dev-middleware': ^3.7.0
       '@types/webpack-hot-middleware': ^2.25.2
+      apollo-server-restify: ^1.3.6
       etag: ^1.8.1
+      graphql: ^15.4.0
       http-proxy-middleware: ^1.0.5
       serverless-http: ^2.4.1
       typescript: ^3.9.2
@@ -842,12 +856,14 @@ importers:
       '@types/node': 13.13.14
       '@types/react': 16.9.55
       '@types/react-dom': 16.9.8
+      graphql: 15.4.0
       typescript: 3.9.7
     specifiers:
       '@not-govuk/app-composer': 'workspace:^0.1.0'
       '@types/node': ^13.13.4
       '@types/react': ^16.9.55
       '@types/react-dom': ^16.9.8
+      graphql: ^15.4.0
       js-beautify: ^1.11.0
       restify-errors: ^8.0.2
       typescript: ^3.9.2
@@ -971,6 +987,71 @@ packages:
     dev: true
     resolution:
       integrity: sha512-HqiDzaLDFCXkcCO/SwoyhRwqYtINFHF7t9BDRq4x90TOKNAJpiqUt9X5lQ08bwxYzc067HUywDjGySpebHcUpw==
+  /@apollo/client/3.2.5_graphql@15.4.0+react@16.14.0:
+    dependencies:
+      '@graphql-typed-document-node/core': 3.1.0_graphql@15.4.0
+      '@types/zen-observable': 0.8.1
+      '@wry/context': 0.5.2
+      '@wry/equality': 0.2.0
+      fast-json-stable-stringify: 2.1.0
+      graphql: 15.4.0
+      graphql-tag: 2.11.0_graphql@15.4.0
+      hoist-non-react-statics: 3.3.2
+      optimism: 0.13.0
+      prop-types: 15.7.2
+      react: 16.14.0
+      symbol-observable: 2.0.3
+      ts-invariant: 0.4.4
+      tslib: 1.13.0
+      zen-observable: 0.8.15
+    dev: true
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+      react: ^16.8.0
+      subscriptions-transport-ws: ^0.9.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      subscriptions-transport-ws:
+        optional: true
+    resolution:
+      integrity: sha512-zpruxnFMz6K94gs2pqc3sidzFDbQpKT5D6P/J/I9s8ekHZ5eczgnRp6pqXC86Bh7+44j/btpmOT0kwiboyqTnA==
+  /@apollo/client/3.2.5_react@16.14.0:
+    dependencies:
+      '@graphql-typed-document-node/core': 3.1.0
+      '@types/zen-observable': 0.8.1
+      '@wry/context': 0.5.2
+      '@wry/equality': 0.2.0
+      fast-json-stable-stringify: 2.1.0
+      graphql-tag: 2.11.0
+      hoist-non-react-statics: 3.3.2
+      optimism: 0.13.0
+      prop-types: 15.7.2
+      react: 16.14.0
+      symbol-observable: 2.0.3
+      ts-invariant: 0.4.4
+      tslib: 1.13.0
+      zen-observable: 0.8.15
+    dev: true
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+      react: ^16.8.0
+      subscriptions-transport-ws: ^0.9.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      subscriptions-transport-ws:
+        optional: true
+    resolution:
+      integrity: sha512-zpruxnFMz6K94gs2pqc3sidzFDbQpKT5D6P/J/I9s8ekHZ5eczgnRp6pqXC86Bh7+44j/btpmOT0kwiboyqTnA==
+  /@ardatan/aggregate-error/0.0.6:
+    dependencies:
+      tslib: 2.0.3
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-vyrkEHG1jrukmzTPtyWB4NLPauUw5bQeg4uhn8f+1SSynmrOcyvlb1GKQjjgoBzElLdfXCRYX8UnBlhklOHYRQ==
   /@babel/code-frame/7.10.4:
     dependencies:
       '@babel/highlight': 7.10.4
@@ -3428,6 +3509,41 @@ packages:
     dev: true
     resolution:
       integrity: sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
+  /@graphql-tools/schema/7.0.0_graphql@15.4.0:
+    dependencies:
+      '@graphql-tools/utils': 7.0.1_graphql@15.4.0
+      graphql: 15.4.0
+      tslib: 2.0.3
+    dev: true
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    resolution:
+      integrity: sha512-yDKgoT2+Uf3cdLYmiFB9lRIGsB6lZhILtCXHgZigYgURExrEPmfj3ZyszfEpPKYcPmKaO9FI4coDhIN0Toxl3w==
+  /@graphql-tools/utils/7.0.1_graphql@15.4.0:
+    dependencies:
+      '@ardatan/aggregate-error': 0.0.6
+      camel-case: 4.1.1
+      graphql: 15.4.0
+      tslib: 2.0.3
+    dev: true
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0
+    resolution:
+      integrity: sha512-DsV7XfEJE6rPQ3Ysusf28MPun/YL+pc7L0hiBOph/F8+/H1pW1ndRqRrnmX3Owrq9xW1EHSw2WU8qvdjn8kOjw==
+  /@graphql-typed-document-node/core/3.1.0:
+    dev: true
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+    resolution:
+      integrity: sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
+  /@graphql-typed-document-node/core/3.1.0_graphql@15.4.0:
+    dependencies:
+      graphql: 15.4.0
+    dev: true
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+    resolution:
+      integrity: sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
   /@icons/material/0.2.4:
     dev: true
     peerDependencies:
@@ -6063,6 +6179,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==
+  /@types/zen-observable/0.8.1:
+    dev: true
+    resolution:
+      integrity: sha512-wmk0xQI6Yy7Fs/il4EpOcflG4uonUpYGqvZARESLc2oy4u69fkatFLbJOeW4Q6awO15P4rduAe6xkwHevpXcUQ==
   /@typescript-eslint/typescript-estree/2.34.0_typescript@3.9.7:
     dependencies:
       debug: 4.1.1
@@ -6242,6 +6362,18 @@ packages:
       webpack: ^3.0.0 || ^4.0.0
     resolution:
       integrity: sha512-LonryJP+FxQQHsjGBi6W786TQB1Oym+agTpY0c+Kj8alnIw+DLUJb6SI8Y1GHGhLCH1yPRrucjObUmxNICQ1pg==
+  /@wry/context/0.5.2:
+    dependencies:
+      tslib: 1.13.0
+    dev: true
+    resolution:
+      integrity: sha512-B/JLuRZ/vbEKHRUiGj6xiMojST1kHhu4WcreLfNN7q9DqQFrb97cWgf/kiYsPSUCAMVN0HzfFc8XjJdzgZzfjw==
+  /@wry/equality/0.2.0:
+    dependencies:
+      tslib: 1.13.0
+    dev: true
+    resolution:
+      integrity: sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==
   /@xtuc/ieee754/1.2.0:
     dev: true
     resolution:
@@ -6581,6 +6713,52 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
+  /apollo-cache-control/0.1.1_graphql@15.4.0:
+    dependencies:
+      graphql: 15.4.0
+      graphql-extensions: 0.0.10_graphql@15.4.0
+    dev: false
+    engines:
+      node: '>=4.0'
+    peerDependencies:
+      graphql: 0.10.x - 0.13.x
+    resolution:
+      integrity: sha512-XJQs167e9u+e5ybSi51nGYr70NPBbswdvTEHtbtXbwkZ+n9t0SLPvUcoqceayOSwjK1XYOdU/EKPawNdb3rLQA==
+  /apollo-server-core/1.4.0_graphql@15.4.0:
+    dependencies:
+      apollo-cache-control: 0.1.1_graphql@15.4.0
+      apollo-tracing: 0.1.4_graphql@15.4.0
+      graphql: 15.4.0
+      graphql-extensions: 0.0.10_graphql@15.4.0
+    dev: false
+    peerDependencies:
+      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0
+    resolution:
+      integrity: sha512-BP1Vh39krgEjkQxbjTdBURUjLHbFq1zeOChDJgaRsMxGtlhzuLWwwC6lLdPatN8jEPbeHq8Tndp9QZ3iQZOKKA==
+  /apollo-server-module-graphiql/1.4.0:
+    dev: false
+    resolution:
+      integrity: sha512-GmkOcb5he2x5gat+TuiTvabnBf1m4jzdecal3XbXBh/Jg+kx4hcvO3TTDFQ9CuTprtzdcVyA11iqG7iOMOt7vA==
+  /apollo-server-restify/1.3.6_graphql@15.4.0:
+    dependencies:
+      apollo-server-core: 1.4.0_graphql@15.4.0
+      apollo-server-module-graphiql: 1.4.0
+    dev: false
+    peerDependencies:
+      graphql: '*'
+    resolution:
+      integrity: sha1-P5NxcX93h1lYnhQQwdHS8dGZFWg=
+  /apollo-tracing/0.1.4_graphql@15.4.0:
+    dependencies:
+      graphql: 15.4.0
+      graphql-extensions: 0.0.10_graphql@15.4.0
+    dev: false
+    engines:
+      node: '>=4.0'
+    peerDependencies:
+      graphql: 0.10.x - 0.13.x
+    resolution:
+      integrity: sha512-Uv+1nh5AsNmC3m130i2u3IqbS+nrxyVV3KYimH5QKsdPjxxIQB3JAT+jJmpeDxBel8gDVstNmCh82QSLxLSIdQ==
   /app-module-path/2.2.0:
     dev: true
     resolution:
@@ -7816,7 +7994,6 @@ packages:
     resolution:
       integrity: sha1-+PeLdniYiO858gXNY39o5wISKyw=
   /buffer-from/1.1.1:
-    dev: true
     resolution:
       integrity: sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
   /buffer-xor/1.0.3:
@@ -8000,7 +8177,7 @@ packages:
   /camel-case/4.1.1:
     dependencies:
       pascal-case: 3.1.1
-      tslib: 1.13.0
+      tslib: 1.14.1
     dev: true
     resolution:
       integrity: sha512-7fa2WcG4fYFkclIvEmxBbTvmibwF2/agfEBc6q3lOpVu0A13ltLsA+Hr/8Hp6kp5f+G7hKi6t8lys6XxP+1K6Q==
@@ -8766,7 +8943,6 @@ packages:
       integrity: sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
   /core-js/2.6.11:
     deprecated: 'core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.'
-    dev: true
     requiresBuild: true
     resolution:
       integrity: sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
@@ -11728,6 +11904,38 @@ packages:
     dev: true
     resolution:
       integrity: sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==
+  /graphql-extensions/0.0.10_graphql@15.4.0:
+    dependencies:
+      core-js: 2.6.11
+      graphql: 15.4.0
+      source-map-support: 0.5.19
+    dev: false
+    engines:
+      node: '>=4.0'
+    peerDependencies:
+      graphql: 0.10.x - 0.13.x
+    resolution:
+      integrity: sha512-TnQueqUDCYzOSrpQb3q1ngDSP2otJSF+9yNLrQGPzkMsvnQ+v6e2d5tl+B35D4y+XpmvVnAn4T3ZK28mkILveA==
+  /graphql-tag/2.11.0:
+    dev: true
+    peerDependencies:
+      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+    resolution:
+      integrity: sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==
+  /graphql-tag/2.11.0_graphql@15.4.0:
+    dependencies:
+      graphql: 15.4.0
+    dev: true
+    peerDependencies:
+      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+    resolution:
+      integrity: sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==
+  /graphql/15.4.0:
+    dev: true
+    engines:
+      node: '>= 10.x'
+    resolution:
+      integrity: sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==
   /growly/1.3.0:
     dev: true
     optional: true
@@ -14628,7 +14836,7 @@ packages:
       integrity: sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
   /lower-case/2.0.1:
     dependencies:
-      tslib: 1.13.0
+      tslib: 1.14.1
     dev: true
     resolution:
       integrity: sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==
@@ -15321,7 +15529,7 @@ packages:
   /no-case/3.0.3:
     dependencies:
       lower-case: 2.0.1
-      tslib: 1.13.0
+      tslib: 1.14.1
     dev: true
     resolution:
       integrity: sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==
@@ -15792,6 +16000,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==
+  /optimism/0.13.0:
+    dependencies:
+      '@wry/context': 0.5.2
+    dev: true
+    resolution:
+      integrity: sha512-6JAh3dH+YUE4QUdsgUw8nUQyrNeBKfAEKOHMlLkQ168KhIYFIxzPsHakWrRXDnTO+x61RJrS3/2uEt6W0xlocA==
   /optionator/0.8.3:
     dependencies:
       deep-is: 0.1.3
@@ -16121,7 +16335,7 @@ packages:
   /pascal-case/3.1.1:
     dependencies:
       no-case: 3.0.3
-      tslib: 1.13.0
+      tslib: 1.14.1
     dev: true
     resolution:
       integrity: sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==
@@ -16944,6 +17158,11 @@ packages:
   /react-color/2.18.1_react@16.14.0:
     dependencies:
       '@icons/material': 0.2.4_react@16.14.0
+      lodash: 4.17.19
+      material-colors: 1.2.6
+      prop-types: 15.7.2
+      reactcss: 1.2.3
+      tinycolor2: 1.4.1
     dev: true
     peerDependencies:
       react: '*'
@@ -18700,7 +18919,6 @@ packages:
     dependencies:
       buffer-from: 1.1.1
       source-map: 0.6.1
-    dev: true
     resolution:
       integrity: sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
   /source-map-url/0.4.0:
@@ -19272,6 +19490,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
+  /symbol-observable/2.0.3:
+    dev: true
+    engines:
+      node: '>=0.10'
+    resolution:
+      integrity: sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==
   /symbol-tree/3.2.4:
     dev: true
     resolution:
@@ -19699,6 +19923,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
+  /ts-invariant/0.4.4:
+    dependencies:
+      tslib: 1.13.0
+    dev: true
+    resolution:
+      integrity: sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
   /ts-jest/26.1.3_jest@26.1.0+typescript@3.9.7:
     dependencies:
       bs-logger: 0.2.6
@@ -19738,10 +19968,18 @@ packages:
   /tslib/1.13.0:
     resolution:
       integrity: sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+  /tslib/1.14.1:
+    dev: true
+    resolution:
+      integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
   /tslib/2.0.0:
     dev: true
     resolution:
       integrity: sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
+  /tslib/2.0.3:
+    dev: true
+    resolution:
+      integrity: sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
   /tsutils/3.17.1_typescript@3.9.7:
     dependencies:
       tslib: 1.13.0
@@ -20921,6 +21159,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-AI4G2AlDIMNy28L47XagymyKxBk=
+  /zen-observable/0.8.15:
+    dev: true
+    resolution:
+      integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
   /zip-stream/2.1.3:
     dependencies:
       archiver-utils: 2.1.0


### PR DESCRIPTION
Add isomorphic GraphQL support as a convenient way to populate components with data from the server.

Begins to address #125.