### PR TITLE
Chromatic: Dirty hack to fix CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "distclean": "pnpm recursive exec -- rm -rf node_modules && rm -rf node_modules",
     "start": "echo 'Error: This is the root of the monorepo, you should run `cd apps/YOUR_APP && npm start` or run `npm run storybook` to start Storybook.' && false",
     "storybook": "start-storybook -p 9009",
-    "build:storybook": "build-storybook",
+    "build:storybook": "build-storybook && touch storybook-static/index.html",
     "clean:storybook": "rm -rf storybook-static",
     "chromatic": "chromatic --exit-zero-on-changes",
     "test": "jest --coverage --json --outputFile=.jest-results.json"


### PR DESCRIPTION
CI is currently failing due to a pre-existing problem with our Storybook
in which the `index.html` file is not built. This works around the
problem by simply touching the file after the build; it seems that
Chromatic does not actually need this file.