### PR TITLE
Footer: Fix: Reference dependency correctly

### DIFF
--- a/components/footer/assets/Footer.scss
+++ b/components/footer/assets/Footer.scss
@@ -3,7 +3,7 @@
 
 .govuk-footer {
   &__copyright-logo {
-    background-image: url('../node_modules/govuk-frontend/govuk/assets/images/govuk-crest.png') !important; // TODO: !important is required due to SCSS being included twice.
+    background-image: url('~govuk-frontend/govuk/assets/images/govuk-crest.png') !important; // TODO: !important is required due to SCSS being included twice.
   }
 
   .govuk-link, a {


### PR DESCRIPTION
We cannot rely on the dependency being installed in an exact location on
the file-system. Instead, we should us the special `~` syntax to do the
module resolution for us.

(Notably, PNPM will _not_ install the dependency where we were
expecting and so the components was broken for our consumers.)