### PR TITLE
app-composer: Supply accessToken to SchemaLink

### DIFF
--- a/lib/app-composer/src/index.ts
+++ b/lib/app-composer/src/index.ts
@@ -81,7 +81,6 @@ type ComposeOptionsCommon = {
   ErrorPage: ErrorPage
   PageWrap: Page
   data: object
-  user?: UserInfo
 };
 
 type ComposeOptionsSSR = ComposeOptionsCommon & {
@@ -89,6 +88,9 @@ type ComposeOptionsSSR = ComposeOptionsCommon & {
     schema: GraphQLSchema
   }
   routerProps: StaticRouterProps
+  user?: UserInfo & {
+    accessToken?: string
+  }
 };
 
 type ComposeOptionsCSR = ComposeOptionsCommon & {
@@ -98,6 +100,7 @@ type ComposeOptionsCSR = ComposeOptionsCommon & {
   }
   pageLoader: PageLoader
   routerProps: BrowserRouterProps
+  user?: UserInfo
 };
 
 export type ComposeOptions = ComposeOptionsCSR | ComposeOptionsSSR;

--- a/lib/server-renderer/src/index.ts
+++ b/lib/server-renderer/src/index.ts
@@ -108,7 +108,7 @@ export const reactRenderer = (AppWrap: ComponentType<ApplicationProps>, PageWrap
       },
       routerProps,
       data,
-      user
+      user: { ...user, accessToken: req.auth?.accessToken }
     });
     const app = h(App, appProps)
 


### PR DESCRIPTION
Without this, the resolvers won't be able to use the token to make
upstream requests.