### PR TITLE
engine: Fix: Remove refresh token for now

### DIFF
--- a/lib/engine/src/lib/auth/oidc.ts
+++ b/lib/engine/src/lib/auth/oidc.ts
@@ -91,8 +91,8 @@ export const oidcAuth: AuthBagger<AuthOptionsOIDC> = async ({
         ...(data.realm_access?.roles || []),
         ...(Object.entries(data.resource_access || {}).reduce(resourceToRoles, []))
       ].filter(id),
-      accessToken: tokenset.access_token,
-      refreshToken: tokenset.refresh_token
+      accessToken: tokenset.access_token//,
+      //refreshToken: tokenset.refresh_token // removed until we can handle it
     };
 
     done(null, user);


### PR DESCRIPTION
The cookie is too big so let's fix that by removing the refresh token
which we do not yet use.

We will later need to add support for the token and so will need to
support larger sessions, probably by splitting the cookie.