### PR TITLE
Add publish script to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY = all deps test tmux
+version ?= next
+
+.PHONY = all deps publish test tmux
 
 all: deps
 
@@ -13,3 +15,11 @@ tmux: deps
 
 node_modules/: package.json packages/*/package.json
 	pnpm install
+
+publish:
+	npm run all:clean
+	git nb 'v$(version)'
+	npm version '$(version)'
+	npm run all:publish
+	git push
+	git push --tags


### PR DESCRIPTION
It should now be possible to publish using the following command:

```shell
make publish version='0.1.34'
```

Note that you should only do this on a completely clean checkout of the
HEAD of the `master` branch.

You should also ensure that your dependencies are up to date by running
`pnpm i`.