### PR TITLE
Load pages in sync mode

### DIFF
--- a/apps/govuk-docs/src/common/page-loader.ts
+++ b/apps/govuk-docs/src/common/page-loader.ts
@@ -1,2 +1,2 @@
-export const pageLoader = require.context('./pages', true, /\.[jt]sx?$/i, 'lazy');
+export const pageLoader = require.context('./pages', true, /\.[jt]sx?$/i, 'sync');
 export default pageLoader;

--- a/apps/govuk-template/src/common/page-loader.ts
+++ b/apps/govuk-template/src/common/page-loader.ts
@@ -1,2 +1,2 @@
-export const pageLoader = require.context('./pages', true, /\.[jt]sx?$/i, 'lazy');
+export const pageLoader = require.context('./pages', true, /\.[jt]sx?$/i, 'sync');
 export default pageLoader;

--- a/components/page/spec/Page.stories.mdx
+++ b/components/page/spec/Page.stories.mdx
@@ -37,7 +37,7 @@ A fully branded page with content sandwiched between the header and footer.
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1>
-            <span class="caption">Caption</span>
+            <span className="caption">Caption</span>
             My page
           </h1>
           <p>My content</p>
@@ -69,7 +69,7 @@ A standard Page.
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1>
-            <span class="caption">Caption</span>
+            <span className="caption">Caption</span>
             My page
           </h1>
           <p>My content</p>
@@ -98,7 +98,7 @@ A page suitable for being hosted on GOV.UK.
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1>
-            <span class="caption">Caption</span>
+            <span className="caption">Caption</span>
             My page
           </h1>
           <p>My content</p>
@@ -126,7 +126,7 @@ A page that does _NOT_ restrict the width on wide screens.
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1>
-            <span class="caption">Caption</span>
+            <span className="caption">Caption</span>
             My page
           </h1>
           <p>My content</p>
@@ -169,7 +169,7 @@ your department in order to use their colours.
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1>
-            <span class="caption">Caption</span>
+            <span className="caption">Caption</span>
             My page
           </h1>
           <p>My content</p>
@@ -206,7 +206,7 @@ your department in order to use their colours.
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1>
-            <span class="caption">Caption</span>
+            <span className="caption">Caption</span>
             My page
           </h1>
           <p>My content</p>
@@ -243,7 +243,7 @@ your department in order to use their colours.
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1>
-            <span class="caption">Caption</span>
+            <span className="caption">Caption</span>
             My page
           </h1>
           <p>My content</p>
@@ -280,7 +280,7 @@ your department in order to use their colours.
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1>
-            <span class="caption">Caption</span>
+            <span className="caption">Caption</span>
             My page
           </h1>
           <p>My content</p>
@@ -318,7 +318,7 @@ your department in order to use their colours.
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1>
-            <span class="caption">Caption</span>
+            <span className="caption">Caption</span>
             My page
           </h1>
           <p>My content</p>
@@ -355,7 +355,7 @@ your department in order to use their colours.
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1>
-            <span class="caption">Caption</span>
+            <span className="caption">Caption</span>
             My page
           </h1>
           <p>My content</p>
@@ -392,7 +392,7 @@ your department in order to use their colours.
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1>
-            <span class="caption">Caption</span>
+            <span className="caption">Caption</span>
             My page
           </h1>
           <p>My content</p>
@@ -429,7 +429,7 @@ your department in order to use their colours.
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1>
-            <span class="caption">Caption</span>
+            <span className="caption">Caption</span>
             My page
           </h1>
           <p>My content</p>
@@ -466,7 +466,7 @@ your department in order to use their colours.
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1>
-            <span class="caption">Caption</span>
+            <span className="caption">Caption</span>
             My page
           </h1>
           <p>My content</p>
@@ -504,7 +504,7 @@ your department in order to use their colours.
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1>
-            <span class="caption">Caption</span>
+            <span className="caption">Caption</span>
             My page
           </h1>
           <p>My content</p>
@@ -541,7 +541,7 @@ your department in order to use their colours.
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1>
-            <span class="caption">Caption</span>
+            <span className="caption">Caption</span>
             My page
           </h1>
           <p>My content</p>
@@ -578,7 +578,7 @@ your department in order to use their colours.
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1>
-            <span class="caption">Caption</span>
+            <span className="caption">Caption</span>
             My page
           </h1>
           <p>My content</p>
@@ -747,7 +747,7 @@ A page with lots of customisation.
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <h1>
-            <span class="caption">Caption</span>
+            <span className="caption">Caption</span>
             My page
           </h1>
           <p>My content</p>

--- a/lib/app-composer/src/index.ts
+++ b/lib/app-composer/src/index.ts
@@ -181,15 +181,24 @@ export const compose: Compose = options => {
   const App = props => {
     const routes = props
       .pages
-      .map(e => ({
-        Component: (
-          "pageLoader" in options
-            ? lazy(() => options.pageLoader(e.src))
-            : e.Component
-        ),
-        href: decodeURI(e.href),
-        title: e.title
-      }));
+      .map(e => {
+        const loaded = (
+          'pageLoader' in options
+            ? options.pageLoader(e.src)
+            : undefined
+        );
+        const Component = e.Component || (
+          loaded instanceof Promise
+            ? lazy(() => loaded)
+            : loaded.default
+        );
+
+        return {
+          Component,
+          href: decodeURI(e.href),
+          title: e.title
+        };
+      });
     const pageProps = {
       routes,
       signInHRef: props.signInHRef,

--- a/lib/engine/src/lib/pages.ts
+++ b/lib/engine/src/lib/pages.ts
@@ -42,15 +42,16 @@ const href2Path = (s: string): string => (
 export const gatherPages = (pageLoader: PageLoader): Promise<PageInfoSSR[]> => Promise.all(
   pageLoader
     .keys()
-    .map(e => (
-      pageLoader(e)
-        .then((mod: PageModule) => ({
-          Component: mod.default,
-          href: src2Href(e),
-          src: e,
-          title: mod.title
-        }) )
-    ) )
+    .map(async e => {
+      const mod: PageModule = await pageLoader(e);
+
+      return {
+        Component: mod.default,
+        href: src2Href(e),
+        src: e,
+        title: mod.title
+      };
+    } )
 );
 
 const pageMiddleware = (title: string) => (req: Request, res: Response, next: Next) => {

--- a/lib/plop-pack/skel/app/src/common/page-loader.ts
+++ b/lib/plop-pack/skel/app/src/common/page-loader.ts
@@ -1,2 +1,2 @@
-export const pageLoader = require.context('./pages', true, /\.[jt]sx?$/i, 'lazy');
+export const pageLoader = require.context('./pages', true, /\.[jt]sx?$/i, 'sync');
 export default pageLoader;


### PR DESCRIPTION
Webpack's `require.context` allows the user to set a mode. When it is
set to `sync` (the default) the module will NOT be wrapped in a promise
as it would be in `lazy` mode and some other modes.

As it is the default mode and as some users might want to set this we
should support it. To do so, we check that whether we have a promise. If
we do, we wrap the project in `lazy` as usual, otherwise there is no
need for the wrap and we can consume the component immediately.

This is useful as, in most cases, the extra chunks produced are so small
as to be not worth bothering with. i.e. Let's just combine them into the
main bundle.

Also, by avoid lazy loading we can avoid the need to flash up the
loading page which I am worried might be an accessibility problem.