### PR TITLE
Titles on component pages

### DIFF
--- a/apps/govuk-docs/src/common/pages/components.tsx
+++ b/apps/govuk-docs/src/common/pages/components.tsx
@@ -1,4 +1,5 @@
 import { FC, Fragment, createElement as h } from 'react';
+import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
 import { A } from '@not-govuk/components';
 import { DocsPage } from '@not-govuk/docs-components';
@@ -32,6 +33,10 @@ const Page: FC<PageProps> = ({ location }) => {
 
   return (
     <div className="govuk-grid-row">
+      <Helmet>
+        <title>Components - NotGovUK</title>
+        <meta name="og:article:section" content="Components" />
+      </Helmet>
       <div className="govuk-grid-column-one-quarter">
         <aside>
           <h2>Components</h2>
@@ -47,7 +52,7 @@ const Page: FC<PageProps> = ({ location }) => {
           stories ? (
             <Fragment>
               <span className="govuk-caption-xl">Components</span>
-              <DocsPage stories={stories} />
+              <DocsPage siteName="NotGovUK" stories={stories} />
             </Fragment>
           ) : (
             componentName ? (

--- a/components/aside/spec/Aside.stories.mdx
+++ b/components/aside/spec/Aside.stories.mdx
@@ -2,12 +2,14 @@ import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
 import { Tag } from '@not-govuk/tag';
 import { Aside } from '../src/Aside';
 import readMe from '../README.md';
-export const title = 'Aside';
 
 <Meta
   title="Aside"
   component={ Aside }
   parameters={ {
+    chromatic: { viewports: [640, 480] },
+    description: 'A component for displaying indirectly related content.',
+    image: 'https://snapshots.chromatic.com/snapshots/5f1488148c817700223adb9a-5ff08dbae29b2700217b5333/capture.png',
     jest: ['Aside'],
     notes: readMe
   } }

--- a/components/back-link/spec/BackLink.stories.mdx
+++ b/components/back-link/spec/BackLink.stories.mdx
@@ -6,6 +6,8 @@ import readMe from '../README.md';
   title="Back link"
   component={BackLink}
   parameters={{
+    chromatic: { viewports: [320, 320] },
+    description: 'A component to help users navigate back one page.',
     jest: ['BackLink'],
     notes: readMe
   }}

--- a/components/breadcrumbs/spec/Breadcrumbs.stories.mdx
+++ b/components/breadcrumbs/spec/Breadcrumbs.stories.mdx
@@ -1,12 +1,13 @@
 import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
 import { Breadcrumbs } from '../src/Breadcrumbs';
 import readMe from '../README.md';
-export const title = 'Breadcrumbs';
 
 <Meta
   title="Breadcrumbs"
   component={ Breadcrumbs }
   parameters={ {
+    chromatic: { viewports: [640, 480] },
+    description: 'A component to help users to understand where they are within a website\'s structure and move between levels.',
     jest: ['Breadcrumbs'],
     notes: readMe
   } }

--- a/components/details/spec/Details.stories.mdx
+++ b/components/details/spec/Details.stories.mdx
@@ -1,12 +1,13 @@
 import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
 import { Details } from '../src/Details';
 import readMe from '../README.md';
-export const title = 'Details';
 
 <Meta
   title="Details"
   component={ Details }
   parameters={ {
+    chromatic: { viewports: [640, 480] },
+    description: 'A component to make a page easier to scan by letting users reveal more detailed information only if they need it.',
     jest: ['Details'],
     notes: readMe
   } }

--- a/components/footer/spec/Footer.stories.mdx
+++ b/components/footer/spec/Footer.stories.mdx
@@ -2,12 +2,13 @@ import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
 import { A } from '@not-govuk/link';
 import { Footer } from '../src/Footer';
 import readMe from '../README.md';
-export const title = 'Footer';
 
 <Meta
   title="Footer"
   component={ Footer }
   parameters={ {
+    chromatic: { viewports: [800, 600] },
+    description: 'A page footer providing copyright, licensing and other information about your service and department.',
     jest: ['Footer'],
     notes: readMe
   } }

--- a/components/form/spec/Form.stories.mdx
+++ b/components/form/spec/Form.stories.mdx
@@ -2,12 +2,13 @@ import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
 import { Tag } from '@not-govuk/tag';
 import { Form, after, past, required } from '../src/Form';
 import readMe from '../README.md';
-export const title = 'Form';
 
 <Meta
   title="Form"
   component={ Form }
   parameters={ {
+    chromatic: { viewports: [640, 480] },
+    description: 'A component to collect information from the user.',
     jest: ['Form'],
     notes: readMe
   } }

--- a/components/header/spec/Header.stories.mdx
+++ b/components/header/spec/Header.stories.mdx
@@ -1,12 +1,13 @@
 import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
 import { Header } from '../src/Header';
 import readMe from '../README.md';
-export const title = 'Header';
 
 <Meta
   title="Header"
   component={ Header }
   parameters={ {
+    chromatic: { viewports: [800, 600] },
+    description: 'A component that shows users whether they are on GOV.UK and which service they are using.',
     jest: ['Header'],
     notes: readMe
   } }

--- a/components/inset-text/spec/InsetText.stories.mdx
+++ b/components/inset-text/spec/InsetText.stories.mdx
@@ -1,12 +1,13 @@
 import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
 import { InsetText } from '../src/InsetText';
 import readMe from '../README.md';
-export const title = 'Inset text';
 
 <Meta
   title="Inset text"
   component={ InsetText }
   parameters={ {
+    chromatic: { viewports: [640, 480] },
+    description: 'A block of text that is inset.',
     jest: ['InsetText'],
     notes: readMe
   } }

--- a/components/link/spec/Link.stories.mdx
+++ b/components/link/spec/Link.stories.mdx
@@ -2,12 +2,13 @@ import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
 import { Tag } from '@not-govuk/tag';
 import { A } from '../src/Link';
 import readMe from '../README.md';
-export const title = 'Link';
 
 <Meta
   title="Link"
   component={ A }
   parameters={ {
+    chromatic: { viewports: [320, 320] },
+    description: 'A drop-in replacement for the \'a\' element with GovUK styling.',
     jest: ['Link'],
     notes: readMe
   } }

--- a/components/page/spec/Page.stories.mdx
+++ b/components/page/spec/Page.stories.mdx
@@ -3,12 +3,14 @@ import { Tag } from '@not-govuk/tag';
 import { Aside } from '@not-govuk/aside';
 import { GovUKPage, NotGovUKPage, Page } from '../src';
 import readMe from '../README.md';
-export const title = 'Page';
 
 <Meta
   title="Page"
   component={ Page }
   parameters={ {
+    chromatic: { viewports: [768, 1024] },
+    description: 'A fully branded page with content sandwiched between the header and footer.',
+    image: 'https://snapshots.chromatic.com/snapshots/5f1488148c817700223adb9a-5ff08dbae29b2700217b538f/capture.png',
     jest: ['Page'],
     notes: readMe
   } }

--- a/components/panel/spec/Panel.stories.mdx
+++ b/components/panel/spec/Panel.stories.mdx
@@ -1,12 +1,14 @@
 import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
 import { Panel } from '../src/Panel';
 import readMe from '../README.md';
-export const title = 'Panel';
 
 <Meta
   title="Panel"
   component={ Panel }
   parameters={ {
+    chromatic: { viewports: [640, 480] },
+    description: 'A visible container used on confirmation or results pages to highlight important content.',
+    image: 'https://snapshots.chromatic.com/snapshots/5f1488148c817700223adb9a-5ff08dbae29b2700217b53b3/capture.png',
     jest: ['Panel'],
     notes: readMe
   } }

--- a/components/phase-banner/spec/PhaseBanner.stories.mdx
+++ b/components/phase-banner/spec/PhaseBanner.stories.mdx
@@ -1,12 +1,13 @@
 import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
 import { PhaseBanner } from '../src/PhaseBanner';
 import readMe from '../README.md';
-export const title = 'Phase banner';
 
 <Meta
   title="Phase banner"
   component={ PhaseBanner }
   parameters={ {
+    chromatic: { viewports: [640, 480] },
+    description: 'A component to show users your service is still being worked on.',
     jest: ['PhaseBanner'],
     notes: readMe
   } }

--- a/components/skip-link/spec/SkipLink.stories.mdx
+++ b/components/skip-link/spec/SkipLink.stories.mdx
@@ -2,12 +2,13 @@ import { Fragment } from 'react';
 import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
 import { SkipLink } from '../src/SkipLink';
 import readMe from '../README.md';
-export const title = 'Skip link';
 
 <Meta
   title="Skip link"
   component={ SkipLink }
   parameters={ {
+    chromatic: { viewports: [640, 480] },
+    description: 'A component to help keyboard-only users skip to the main content on a page.',
     jest: ['SkipLink'],
     notes: readMe
   } }

--- a/components/table/spec/Table.stories.mdx
+++ b/components/table/spec/Table.stories.mdx
@@ -1,12 +1,13 @@
 import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
 import { Table } from '../src/Table';
 import readMe from '../README.md';
-export const title = 'Table';
 
 <Meta
   title="Table"
   component={ Table }
   parameters={ {
+    chromatic: { viewports: [640, 480] },
+    description: 'A component to make information easier to compare and scan for users.',
     jest: ['Table'],
     notes: readMe
   } }

--- a/components/tag/spec/Tag.stories.mdx
+++ b/components/tag/spec/Tag.stories.mdx
@@ -1,12 +1,13 @@
 import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
 import { Tag } from '../src/Tag';
 import readMe from '../README.md';
-export const title = 'Tag';
 
 <Meta
   title="Tag"
   component={ Tag }
   parameters={ {
+    chromatic: { viewports: [320, 320] },
+    description: 'A component to display the status of something.',
     jest: ['Tag'],
     notes: readMe
   } }

--- a/components/warning-text/spec/WarningText.stories.mdx
+++ b/components/warning-text/spec/WarningText.stories.mdx
@@ -1,12 +1,13 @@
 import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
 import { WarningText } from '../src/WarningText';
 import readMe from '../README.md';
-export const title = 'Warning text';
 
 <Meta
   title="Warning text"
   component={ WarningText }
   parameters={ {
+    chromatic: { viewports: [640, 480] },
+    description: 'A component to warn the user of something important.',
     jest: ['WarningText'],
     notes: readMe
   } }

--- a/components/width-container/spec/WidthContainer.stories.mdx
+++ b/components/width-container/spec/WidthContainer.stories.mdx
@@ -3,12 +3,13 @@ import { Panel } from '@not-govuk/panel';
 import { Tag } from '@not-govuk/tag';
 import { WidthContainer } from '../src/WidthContainer';
 import readMe from '../README.md';
-export const title = 'Width container';
 
 <Meta
   title="Width container"
   component={ WidthContainer }
   parameters={ {
+    chromatic: { viewports: [640, 480] },
+    description: 'A simple container to limit the width of its contents.',
     jest: ['WidthContainer'],
     notes: readMe
   } }

--- a/lib/docs-components/src/DocsPage.tsx
+++ b/lib/docs-components/src/DocsPage.tsx
@@ -1,4 +1,5 @@
-import { FC, ReactNode, createElement as h } from 'react';
+import { FC, createElement as h } from 'react';
+import { Helmet } from 'react-helmet-async';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 import { DocsContext } from './context';
 
@@ -6,19 +7,32 @@ export type StoriesModule = object & {
   default: {
     includeStories: string[]
     parameters: {
+      description?: string
       docs: {
         page: () => JSX.Element
       }
+      image?: string
     }
+    title: string
   }
 };
 
 export type DocsPageProps = StandardProps & {
+  siteName?: string
   stories: StoriesModule
 };
 
-export const DocsPage: FC<DocsPageProps> = ({ classBlock, classModifiers, className, stories, ...attrs }) => {
+export const DocsPage: FC<DocsPageProps> = ({
+  classBlock,
+  classModifiers,
+  className,
+  siteName,
+  stories,
+  ...attrs
+}) => {
   const classes = classBuilder('penultimate-docs-page', classBlock, classModifiers, className);
+  const title = stories.default.title;
+  const { description, image } = stories.default.parameters;
   const content = stories.default.parameters.docs.page();
 
   const storyNamesToSources = (acc: object, cur: string) => {
@@ -35,6 +49,26 @@ export const DocsPage: FC<DocsPageProps> = ({ classBlock, classModifiers, classN
 
   return (
     <div {...attrs} className={classes()}>
+      { !title ? null : (
+        <Helmet>
+          <title>{title}{ !siteName ? null : ` - ${siteName}`}</title>
+          <meta name="og:title" content={title} />
+        </Helmet>
+      ) }
+      { !description ? null : (
+        <Helmet>
+          <meta name="description" content={description} />
+          <meta name="og:description" content={description} />
+        </Helmet>
+      ) }
+      { !image ? null : (
+        <Helmet>
+          <meta name="og:image" content={image} />
+        </Helmet>
+      ) }
+      <Helmet>
+        <meta name="og:type" content="article" />
+      </Helmet>
       <DocsContext.Provider value={contextValue}>
         {content}
       </DocsContext.Provider>

--- a/lib/plop-pack/skel/component/spec/Component.stories.mdx.hbs
+++ b/lib/plop-pack/skel/component/spec/Component.stories.mdx.hbs
@@ -1,12 +1,13 @@
 import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
 import { {{{properCase name}}} } from '../src/{{{properCase name}}}';
 import readMe from '../README.md';
-export const title = '{{{name}}}';
 
 <Meta
   title="{{{name}}}"
   component={ {{{properCase name}}} }
   parameters={ {
+    chromatic: { viewports: [640, 480] },
+    description: '{{{description}}}',
     jest: ['{{{properCase name}}}'],
     notes: readMe
   } }


### PR DESCRIPTION
Adds custom titles to the component pages for accessibility (and correctness).

Also provides OpenGraph meta-data which should help when the pages are shared via things like Slack.