### PR TITLE
Add Heroku support to the applications

### DIFF
--- a/apps/govuk-template/package.json
+++ b/apps/govuk-template/package.json
@@ -9,12 +9,20 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack",
     "package:serverless": "sls package",
+    "postinstall": "npm run build",
     "clean": "rm -rf .serverless dist",
     "dev": "NODE_ENV=development node-hot --fork | bunyan",
     "dev:ssr": "NODE_ENV=development SSR_ONLY=true node-hot --fork | bunyan"
   },
   "author": "Daniel A.C. Martin <npm@daniel-martin.co.uk> (http://daniel-martin.co.uk/)",
   "license": "MIT",
+  "engines": {
+    "node": ">=12.0.0",
+    "os": [
+      "darwin",
+      "linux"
+    ]
+  },
   "devDependencies": {
     "@apollo/client": "^3.2.3",
     "@graphql-tools/schema": "^7.0.0",

--- a/apps/govuk-template/src/server/config.ts
+++ b/apps/govuk-template/src/server/config.ts
@@ -29,7 +29,7 @@ const serverConfig = {
   env,
   httpd: {
     host: process.env.LISTEN_HOST || '0.0.0.0',
-    port: Number(process.env.LISTEN_PORT) || 8080
+    port: Number(process.env.LISTEN_PORT) || Number(process.env.PORT) || 8080
   },
   mode: (process.env.MODE || 'server') as Mode,
   ssrOnly: !!(process.env.SSR_ONLY && process.env.SSR_ONLY.match(/(yes|true)/i))

--- a/lib/plop-pack/skel/app/package.json.hbs
+++ b/lib/plop-pack/skel/app/package.json.hbs
@@ -9,12 +9,20 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack",
     "package:serverless": "sls package",
+    "postinstall": "npm run build",
     "clean": "rm -rf .serverless dist",
     "dev": "NODE_ENV=development node-hot --fork | bunyan",
     "dev:ssr": "NODE_ENV=development SSR_ONLY=true node-hot --fork | bunyan"
   },
   "author": "{{{pkg 'author'}}}",
   "license": "{{{pkg 'license'}}}",
+  "engines": {
+    "node": ">=12.0.0",
+    "os": [
+      "darwin",
+      "linux"
+    ]
+  },
   "devDependencies": {
     "@apollo/client": "^3.2.3",
     "@graphql-tools/schema": "^7.0.0",


### PR DESCRIPTION
This will allow Heroku to tell us which port to listen on as well as to
automatically build the application and to use a supported version of
Node.js.