### PR TITLE
server-renderer: Fix HTML hot-loading

### DIFF
--- a/lib/server-renderer/src/index.ts
+++ b/lib/server-renderer/src/index.ts
@@ -160,7 +160,12 @@ export const reactRenderer: ReactRenderer = ({
           ssrOnly
             ? undefined
             : {
-              props: appProps,
+              props: {
+                ...appProps,
+                pages: appProps.pages.map(
+                  ({ Component, ...rest }) => ({ ...rest })
+                )
+              },
               cache: App.extractDataCache(),
               user
             }


### PR DESCRIPTION
The HTML pages were being placed in the hydration data and so were not
subject to hot-loading. To fix this, we explicitly filter out the
`Component` property rather than relying on `JSON.stringify()` to do it
for us.