### PR TITLE
Update govuk-frontend and pin version

### DIFF
--- a/components/aside/package.json
+++ b/components/aside/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@not-govuk/component-helpers": "workspace:^0.2.0",
     "@not-govuk/sass-base": "workspace:^0.2.0",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/components/back-link/package.json
+++ b/components/back-link/package.json
@@ -27,7 +27,7 @@
     "@not-govuk/component-helpers": "workspace:^0.2.0",
     "@not-govuk/link": "workspace:^0.2.0",
     "@not-govuk/sass-base": "workspace:^0.2.0",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/components/breadcrumbs/package.json
+++ b/components/breadcrumbs/package.json
@@ -27,7 +27,7 @@
     "@not-govuk/anchor-list": "workspace:^0.2.0",
     "@not-govuk/component-helpers": "workspace:^0.2.0",
     "@not-govuk/sass-base": "workspace:^0.2.0",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/components/details/package.json
+++ b/components/details/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@not-govuk/component-helpers": "workspace:^0.2.0",
     "@not-govuk/sass-base": "workspace:^0.2.0",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/components/footer/package.json
+++ b/components/footer/package.json
@@ -28,7 +28,7 @@
     "@not-govuk/link": "workspace:^0.2.0",
     "@not-govuk/sass-base": "workspace:^0.2.0",
     "@not-govuk/width-container": "workspace:^0.2.0",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/components/header/package.json
+++ b/components/header/package.json
@@ -28,7 +28,7 @@
     "@not-govuk/link": "workspace:^0.2.0",
     "@not-govuk/sass-base": "workspace:^0.2.0",
     "@not-govuk/width-container": "workspace:^0.2.0",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/components/inset-text/package.json
+++ b/components/inset-text/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@not-govuk/component-helpers": "workspace:^0.2.0",
     "@not-govuk/sass-base": "workspace:^0.2.0",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/components/link/package.json
+++ b/components/link/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@not-govuk/anchor": "workspace:^0.2.0",
     "@not-govuk/sass-base": "workspace:^0.2.0",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/components/navigation-menu/package.json
+++ b/components/navigation-menu/package.json
@@ -27,7 +27,7 @@
     "@not-govuk/anchor-list": "workspace:^0.2.5",
     "@not-govuk/component-helpers": "workspace:^0.2.5",
     "@not-govuk/sass-base": "workspace:^0.2.5",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/components/page/package.json
+++ b/components/page/package.json
@@ -34,7 +34,7 @@
     "@not-govuk/sass-base": "workspace:^0.2.0",
     "@not-govuk/skip-link": "workspace:^0.2.0",
     "@not-govuk/width-container": "workspace:^0.2.0",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/components/panel/package.json
+++ b/components/panel/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@not-govuk/component-helpers": "workspace:^0.2.0",
     "@not-govuk/sass-base": "workspace:^0.2.0",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/components/phase-banner/package.json
+++ b/components/phase-banner/package.json
@@ -27,7 +27,7 @@
     "@not-govuk/component-helpers": "workspace:^0.2.0",
     "@not-govuk/sass-base": "workspace:^0.2.0",
     "@not-govuk/tag": "workspace:^0.2.0",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/components/skip-link/package.json
+++ b/components/skip-link/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@not-govuk/component-helpers": "workspace:^0.2.0",
     "@not-govuk/sass-base": "workspace:^0.2.0",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/components/table/package.json
+++ b/components/table/package.json
@@ -27,7 +27,7 @@
     "@not-govuk/component-helpers": "workspace:^0.2.0",
     "@not-govuk/sass-base": "workspace:^0.2.0",
     "@not-govuk/simple-table": "workspace:^0.2.0",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/components/tabs/package.json
+++ b/components/tabs/package.json
@@ -27,7 +27,7 @@
     "@not-govuk/component-helpers": "workspace:^0.2.2",
     "@not-govuk/route-utils": "workspace:^0.2.6",
     "@not-govuk/sass-base": "workspace:^0.2.1",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/components/tag/package.json
+++ b/components/tag/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@not-govuk/component-helpers": "workspace:^0.2.0",
     "@not-govuk/sass-base": "workspace:^0.2.0",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/components/warning-text/package.json
+++ b/components/warning-text/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@not-govuk/component-helpers": "workspace:^0.2.0",
     "@not-govuk/sass-base": "workspace:^0.2.0",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/components/width-container/package.json
+++ b/components/width-container/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@not-govuk/component-helpers": "workspace:^0.2.0",
     "@not-govuk/sass-base": "workspace:^0.2.0",
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0",

--- a/lib-govuk/sass-base/package.json
+++ b/lib-govuk/sass-base/package.json
@@ -13,6 +13,6 @@
   "author": "Daniel A.C. Martin <npm@daniel-martin.co.uk> (http://daniel-martin.co.uk/)",
   "license": "MIT",
   "dependencies": {
-    "govuk-frontend": "^3.9.1"
+    "govuk-frontend": "3.11.0"
   }
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -75,7 +75,7 @@
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.15.1",
     "enzyme-to-json": "^3.4.3",
-    "govuk-frontend": "^3.9.1",
+    "govuk-frontend": "3.11.0",
     "typescript": "^3.9.2"
   },
   "browserslist": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,7 +286,7 @@ importers:
     dependencies:
       '@not-govuk/component-helpers': 'link:../../lib/component-helpers'
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22
       '@not-govuk/component-test-helpers': 'link:../../lib/component-test-helpers'
@@ -302,7 +302,7 @@ importers:
       '@not-govuk/sass-base': 'workspace:^0.2.0'
       '@not-govuk/tag': 'workspace:^0.2.0'
       '@types/react': ^16.9.35
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -311,7 +311,7 @@ importers:
       '@not-govuk/component-helpers': 'link:../../lib/component-helpers'
       '@not-govuk/link': 'link:../link'
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.11
       '@not-govuk/component-test-helpers': 'link:../../lib/component-test-helpers'
@@ -326,7 +326,7 @@ importers:
       '@not-govuk/link': 'workspace:^0.2.0'
       '@not-govuk/sass-base': 'workspace:^0.2.0'
       '@types/react': ^16.9.55
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -335,7 +335,7 @@ importers:
       '@not-govuk/anchor-list': 'link:../../components-internal/anchor-list'
       '@not-govuk/component-helpers': 'link:../../lib/component-helpers'
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.21
       '@not-govuk/component-test-helpers': 'link:../../lib/component-test-helpers'
@@ -350,7 +350,7 @@ importers:
       '@not-govuk/component-test-helpers': 'workspace:^0.2.0'
       '@not-govuk/sass-base': 'workspace:^0.2.0'
       '@types/react': ^16.9.35
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -358,7 +358,7 @@ importers:
     dependencies:
       '@not-govuk/component-helpers': 'link:../../lib/component-helpers'
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22
       '@not-govuk/component-test-helpers': 'link:../../lib/component-test-helpers'
@@ -372,7 +372,7 @@ importers:
       '@not-govuk/component-test-helpers': 'workspace:^0.2.0'
       '@not-govuk/sass-base': 'workspace:^0.2.0'
       '@types/react': ^16.9.35
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -382,7 +382,7 @@ importers:
       '@not-govuk/link': 'link:../link'
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
       '@not-govuk/width-container': 'link:../width-container'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.11
       '@not-govuk/component-test-helpers': 'link:../../lib/component-test-helpers'
@@ -398,7 +398,7 @@ importers:
       '@not-govuk/sass-base': 'workspace:^0.2.0'
       '@not-govuk/width-container': 'workspace:^0.2.0'
       '@types/react': ^16.9.55
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -432,7 +432,7 @@ importers:
       '@not-govuk/link': 'link:../link'
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
       '@not-govuk/width-container': 'link:../width-container'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.19
       '@not-govuk/component-test-helpers': 'link:../../lib/component-test-helpers'
@@ -448,7 +448,7 @@ importers:
       '@not-govuk/sass-base': 'workspace:^0.2.0'
       '@not-govuk/width-container': 'workspace:^0.2.0'
       '@types/react': ^16.9.55
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -456,7 +456,7 @@ importers:
     dependencies:
       '@not-govuk/component-helpers': 'link:../../lib/component-helpers'
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.11
       '@not-govuk/component-test-helpers': 'link:../../lib/component-test-helpers'
@@ -470,7 +470,7 @@ importers:
       '@not-govuk/component-test-helpers': 'workspace:^0.2.0'
       '@not-govuk/sass-base': 'workspace:^0.2.0'
       '@types/react': ^16.9.55
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -478,7 +478,7 @@ importers:
     dependencies:
       '@not-govuk/anchor': 'link:../../components-internal/anchor'
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.11
       '@not-govuk/component-test-helpers': 'link:../../lib/component-test-helpers'
@@ -494,7 +494,7 @@ importers:
       '@not-govuk/sass-base': 'workspace:^0.2.0'
       '@not-govuk/tag': 'workspace:^0.2.0'
       '@types/react': ^16.9.55
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -503,7 +503,7 @@ importers:
       '@not-govuk/anchor-list': 'link:../../components-internal/anchor-list'
       '@not-govuk/component-helpers': 'link:../../lib/component-helpers'
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22
       '@not-govuk/anchor': 'link:../../components-internal/anchor'
@@ -522,7 +522,7 @@ importers:
       '@not-govuk/sass-base': 'workspace:^0.2.5'
       '@not-govuk/tag': 'workspace:^0.2.5'
       '@types/react': ^16.9.35
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -538,7 +538,7 @@ importers:
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
       '@not-govuk/skip-link': 'link:../skip-link'
       '@not-govuk/width-container': 'link:../width-container'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.19
       '@not-govuk/aside': 'link:../aside'
@@ -564,7 +564,7 @@ importers:
       '@not-govuk/tag': 'workspace:^0.2.0'
       '@not-govuk/width-container': 'workspace:^0.2.0'
       '@types/react': ^16.9.35
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -572,7 +572,7 @@ importers:
     dependencies:
       '@not-govuk/component-helpers': 'link:../../lib/component-helpers'
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.11
       '@not-govuk/component-test-helpers': 'link:../../lib/component-test-helpers'
@@ -586,7 +586,7 @@ importers:
       '@not-govuk/component-test-helpers': 'workspace:^0.2.0'
       '@not-govuk/sass-base': 'workspace:^0.2.0'
       '@types/react': ^16.9.55
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -595,7 +595,7 @@ importers:
       '@not-govuk/component-helpers': 'link:../../lib/component-helpers'
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
       '@not-govuk/tag': 'link:../tag'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22
       '@not-govuk/component-test-helpers': 'link:../../lib/component-test-helpers'
@@ -610,7 +610,7 @@ importers:
       '@not-govuk/sass-base': 'workspace:^0.2.0'
       '@not-govuk/tag': 'workspace:^0.2.0'
       '@types/react': ^16.9.35
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -618,7 +618,7 @@ importers:
     dependencies:
       '@not-govuk/component-helpers': 'link:../../lib/component-helpers'
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.21
       '@not-govuk/component-test-helpers': 'link:../../lib/component-test-helpers'
@@ -632,7 +632,7 @@ importers:
       '@not-govuk/component-test-helpers': 'workspace:^0.2.0'
       '@not-govuk/sass-base': 'workspace:^0.2.0'
       '@types/react': ^16.9.35
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -641,7 +641,7 @@ importers:
       '@not-govuk/component-helpers': 'link:../../lib/component-helpers'
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
       '@not-govuk/simple-table': 'link:../../components-internal/simple-table'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.11
       '@not-govuk/component-test-helpers': 'link:../../lib/component-test-helpers'
@@ -656,7 +656,7 @@ importers:
       '@not-govuk/sass-base': 'workspace:^0.2.0'
       '@not-govuk/simple-table': 'workspace:^0.2.0'
       '@types/react': ^16.9.55
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -665,7 +665,7 @@ importers:
       '@not-govuk/component-helpers': 'link:../../lib/component-helpers'
       '@not-govuk/route-utils': 'link:../../lib/route-utils'
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22
       '@not-govuk/component-test-helpers': 'link:../../lib/component-test-helpers'
@@ -684,7 +684,7 @@ importers:
       '@not-govuk/table': 'workspace:^0.2.1'
       '@not-govuk/tag': 'workspace:^0.2.1'
       '@types/react': ^16.9.35
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -692,7 +692,7 @@ importers:
     dependencies:
       '@not-govuk/component-helpers': 'link:../../lib/component-helpers'
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.11
       '@not-govuk/component-test-helpers': 'link:../../lib/component-test-helpers'
@@ -708,7 +708,7 @@ importers:
       '@not-govuk/sass-base': 'workspace:^0.2.0'
       '@not-govuk/table': 'workspace:^0.2.1'
       '@types/react': ^16.9.55
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -716,7 +716,7 @@ importers:
     dependencies:
       '@not-govuk/component-helpers': 'link:../../lib/component-helpers'
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.11
       '@not-govuk/component-test-helpers': 'link:../../lib/component-test-helpers'
@@ -730,7 +730,7 @@ importers:
       '@not-govuk/component-test-helpers': 'workspace:^0.2.0'
       '@not-govuk/sass-base': 'workspace:^0.2.0'
       '@types/react': ^16.9.55
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -738,7 +738,7 @@ importers:
     dependencies:
       '@not-govuk/component-helpers': 'link:../../lib/component-helpers'
       '@not-govuk/sass-base': 'link:../../lib-govuk/sass-base'
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.19
       '@not-govuk/component-test-helpers': 'link:../../lib/component-test-helpers'
@@ -756,7 +756,7 @@ importers:
       '@not-govuk/sass-base': 'workspace:^0.2.0'
       '@not-govuk/tag': 'workspace:^0.2.0'
       '@types/react': ^16.9.55
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       jest: ^26.1.0
       ts-jest: ^26.1.1
       typescript: ^3.9.2
@@ -838,9 +838,9 @@ importers:
       '@not-govuk/plop-pack-internal': 'workspace:^0.2.0'
   lib-govuk/sass-base:
     dependencies:
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     specifiers:
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
   lib/app-composer:
     dependencies:
       '@not-govuk/route-utils': 'link:../route-utils'
@@ -1304,7 +1304,7 @@ importers:
       enzyme: 3.11.0
       enzyme-adapter-react-16: 1.15.2_enzyme@3.11.0
       enzyme-to-json: 3.5.0_enzyme@3.11.0
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       typescript: 3.9.7
     specifiers:
       '@not-govuk/aside': 'workspace:^0.2.0'
@@ -1339,7 +1339,7 @@ importers:
       enzyme-adapter-react-16: ^1.15.1
       enzyme-to-json: ^3.4.3
       formik: ^2.1.2
-      govuk-frontend: ^3.9.1
+      govuk-frontend: 3.11.0
       qs: ^6.9.1
       typescript: ^3.9.2
       url-parse: ^1.4.7
@@ -2789,7 +2789,7 @@ packages:
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2807,7 +2807,7 @@ packages:
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2950,7 +2950,7 @@ packages:
   /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2968,7 +2968,7 @@ packages:
   /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.12.3:
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.13.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -14728,11 +14728,11 @@ packages:
       node: '>=8.6'
     resolution:
       integrity: sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==
-  /govuk-frontend/3.9.1:
+  /govuk-frontend/3.11.0:
     engines:
       node: '>= 4.2.0'
     resolution:
-      integrity: sha512-ouOoDUj0QwDA4uCHIBkGCFMpORuTRcSuDscOrz7V1PBcOecntLglxJAZAuNm+j2sPo7anoScHU0ZSeE2QIoeAg==
+      integrity: sha512-1hW/3etYBtKPM+PNdWVOijvWVI3mpYL8eb7WLTtlh/Qxf2mCp6LkCsZk9I034n4EJBYQ5jlUWsUlTOOIypftpg==
   /graceful-fs/4.2.4:
     resolution:
       integrity: sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==


### PR DESCRIPTION
It is neceassary to pin the version to avoid a conflict with the most
recent version.