### PR TITLE
Fix: Provide correct the props to PageWrap

### DIFF
--- a/lib/app-composer/src/index.ts
+++ b/lib/app-composer/src/index.ts
@@ -229,12 +229,12 @@ export const compose: Compose = options => {
           title: e.title
         };
       });
-    const withPageWrap = Component => props => {
+    const withPageWrap = Component => componentProps => {
       const fullProps = {
         routes,
         signInHRef: props.signInHRef,
         signOutHRef: props.signOutHRef,
-        ...props
+        ...componentProps
       };
 
       return h(

--- a/lib/engine/src/lib/auth/index.ts
+++ b/lib/engine/src/lib/auth/index.ts
@@ -38,7 +38,6 @@ const buildTools = async (options: Promised<AuthBag>): Promise<AuthTools> => {
       httpd.use(userInfo);
     }
 
-
     if (authenticate) {
       if (siteWide) {
         httpd.use(authenticate);


### PR DESCRIPTION
We were clobbering one of the variables.

This was preventing the log-in option from appearing in the auto-generated navigation menu.