### PR TITLE
Harmonise govuk-frontend versions

### DIFF
--- a/components/button-group/package.json
+++ b/components/button-group/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@not-govuk/component-helpers": "workspace:^0.3.0",
     "@not-govuk/sass-base": "workspace:^0.3.0",
-    "govuk-frontend": "3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",

--- a/components/button/package.json
+++ b/components/button/package.json
@@ -27,7 +27,7 @@
     "@not-govuk/component-helpers": "workspace:^0.3.0",
     "@not-govuk/link": "workspace:^0.3.0",
     "@not-govuk/sass-base": "workspace:^0.3.0",
-    "govuk-frontend": "3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",

--- a/components/checkboxes/package.json
+++ b/components/checkboxes/package.json
@@ -29,7 +29,7 @@
     "@not-govuk/hint": "workspace:^0.3.0",
     "@not-govuk/label": "workspace:^0.3.0",
     "@not-govuk/sass-base": "workspace:^0.3.0",
-    "govuk-frontend": "3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",

--- a/components/cookie-banner/package.json
+++ b/components/cookie-banner/package.json
@@ -28,7 +28,7 @@
     "@not-govuk/component-helpers": "workspace:^0.3.0",
     "@not-govuk/sass-base": "workspace:^0.3.0",
     "@not-govuk/width-container": "workspace:^0.3.4",
-    "govuk-frontend": "3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.3.0",

--- a/components/date-input/package.json
+++ b/components/date-input/package.json
@@ -29,7 +29,7 @@
     "@not-govuk/input": "workspace:^0.3.0",
     "@not-govuk/label": "workspace:^0.3.0",
     "@not-govuk/sass-base": "workspace:^0.3.0",
-    "govuk-frontend": "3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",

--- a/components/error-message/package.json
+++ b/components/error-message/package.json
@@ -27,7 +27,7 @@
     "@not-govuk/component-helpers": "workspace:^0.3.0",
     "@not-govuk/sass-base": "workspace:^0.3.0",
     "@not-govuk/visually-hidden": "workspace:^0.3.0",
-    "govuk-frontend": "3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",

--- a/components/fieldset/package.json
+++ b/components/fieldset/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@not-govuk/component-helpers": "workspace:^0.3.0",
     "@not-govuk/sass-base": "workspace:^0.3.0",
-    "govuk-frontend": "3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",

--- a/components/form-group/package.json
+++ b/components/form-group/package.json
@@ -30,7 +30,7 @@
     "@not-govuk/hint": "workspace:^0.3.0",
     "@not-govuk/label": "workspace:^0.3.0",
     "@not-govuk/sass-base": "workspace:^0.3.0",
-    "govuk-frontend": "3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",

--- a/components/hint/package.json
+++ b/components/hint/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@not-govuk/component-helpers": "workspace:^0.3.0",
     "@not-govuk/sass-base": "workspace:^0.3.0",
-    "govuk-frontend": "3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",

--- a/components/input/package.json
+++ b/components/input/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@not-govuk/component-helpers": "workspace:^0.3.0",
     "@not-govuk/sass-base": "workspace:^0.3.0",
-    "govuk-frontend": "3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",

--- a/components/label/package.json
+++ b/components/label/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@not-govuk/component-helpers": "workspace:^0.3.0",
     "@not-govuk/sass-base": "workspace:^0.3.0",
-    "govuk-frontend": "3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",

--- a/components/radios/package.json
+++ b/components/radios/package.json
@@ -29,7 +29,7 @@
     "@not-govuk/hint": "workspace:^0.3.0",
     "@not-govuk/label": "workspace:^0.3.0",
     "@not-govuk/sass-base": "workspace:^0.3.0",
-    "govuk-frontend": "3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",

--- a/components/select/package.json
+++ b/components/select/package.json
@@ -27,7 +27,7 @@
     "@not-govuk/component-helpers": "workspace:^0.3.0",
     "@not-govuk/form-group": "workspace:^0.3.0",
     "@not-govuk/sass-base": "workspace:^0.3.0",
-    "govuk-frontend": "3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",

--- a/components/textarea/package.json
+++ b/components/textarea/package.json
@@ -27,7 +27,7 @@
     "@not-govuk/component-helpers": "workspace:^0.3.0",
     "@not-govuk/form-group": "workspace:^0.3.0",
     "@not-govuk/sass-base": "workspace:^0.3.0",
-    "govuk-frontend": "3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",

--- a/components/visually-hidden/package.json
+++ b/components/visually-hidden/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@not-govuk/component-helpers": "workspace:^0.3.0",
     "@not-govuk/sass-base": "workspace:^0.3.0",
-    "govuk-frontend": "3.9.1"
+    "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",

--- a/package.json
+++ b/package.json
@@ -88,10 +88,5 @@
     "webpack": "4.43.0",
     "webpack-dev-middleware": "3.7.2",
     "webpack-hot-middleware": "2.25.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "govuk-frontend": "3.9.1"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,5 @@
 lockfileVersion: 5.3
 
-overrides:
-  govuk-frontend: 3.9.1
-
 importers:
 
   .:
@@ -333,14 +330,14 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/tag': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
     dependencies:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -358,7 +355,7 @@ importers:
       '@not-govuk/link': workspace:^0.3.0
       '@not-govuk/sass-base': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -366,7 +363,7 @@ importers:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/link': link:../link
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -383,7 +380,7 @@ importers:
       '@not-govuk/component-test-helpers': workspace:^0.3.0
       '@not-govuk/sass-base': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -391,7 +388,7 @@ importers:
       '@not-govuk/anchor-list': link:../../components-internal/anchor-list
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -410,7 +407,7 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/tag': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -418,7 +415,7 @@ importers:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/link': link:../link
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/button-group': link:../button-group
@@ -438,14 +435,14 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/tag': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
     dependencies:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -467,7 +464,7 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/text-input': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -477,7 +474,7 @@ importers:
       '@not-govuk/hint': link:../hint
       '@not-govuk/label': link:../label
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -499,7 +496,7 @@ importers:
       '@not-govuk/tag': workspace:^0.3.4
       '@not-govuk/width-container': workspace:^0.3.4
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -508,7 +505,7 @@ importers:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
       '@not-govuk/width-container': link:../width-container
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/button': link:../button
@@ -530,7 +527,7 @@ importers:
       '@not-govuk/label': workspace:^0.3.0
       '@not-govuk/sass-base': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -540,7 +537,7 @@ importers:
       '@not-govuk/input': link:../input
       '@not-govuk/label': link:../label
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -556,14 +553,14 @@ importers:
       '@not-govuk/component-test-helpers': workspace:^0.3.0
       '@not-govuk/sass-base': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
     dependencies:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -580,7 +577,7 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/visually-hidden': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -588,7 +585,7 @@ importers:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
       '@not-govuk/visually-hidden': link:../visually-hidden
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -607,14 +604,14 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/visually-hidden': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
     dependencies:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -635,7 +632,7 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/width-container': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -644,7 +641,7 @@ importers:
       '@not-govuk/link': link:../link
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
       '@not-govuk/width-container': link:../width-container
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -735,7 +732,7 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/tag': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -746,7 +743,7 @@ importers:
       '@not-govuk/hint': link:../hint
       '@not-govuk/label': link:../label
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -765,7 +762,7 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/width-container': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -774,7 +771,7 @@ importers:
       '@not-govuk/link': link:../link
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
       '@not-govuk/width-container': link:../width-container
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -791,14 +788,14 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/tag': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
     dependencies:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -816,14 +813,14 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/tag': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
     dependencies:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -840,14 +837,14 @@ importers:
       '@not-govuk/component-test-helpers': workspace:^0.3.0
       '@not-govuk/sass-base': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
     dependencies:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -864,14 +861,14 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/tag': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
     dependencies:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -889,14 +886,14 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/tag': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
     dependencies:
       '@not-govuk/anchor': link:../../components-internal/anchor
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -916,7 +913,7 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/tag': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -924,7 +921,7 @@ importers:
       '@not-govuk/anchor-list': link:../../components-internal/anchor-list
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/anchor': link:../../components-internal/anchor
@@ -952,7 +949,7 @@ importers:
       '@not-govuk/tag': workspace:^0.3.0
       '@not-govuk/width-container': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -967,7 +964,7 @@ importers:
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
       '@not-govuk/skip-link': link:../skip-link
       '@not-govuk/width-container': link:../width-container
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/aside': link:../aside
@@ -985,14 +982,14 @@ importers:
       '@not-govuk/component-test-helpers': workspace:^0.3.0
       '@not-govuk/sass-base': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
     dependencies:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -1009,7 +1006,7 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/tag': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -1017,7 +1014,7 @@ importers:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
       '@not-govuk/tag': link:../tag
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -1037,7 +1034,7 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/text-input': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -1047,7 +1044,7 @@ importers:
       '@not-govuk/hint': link:../hint
       '@not-govuk/label': link:../label
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -1065,7 +1062,7 @@ importers:
       '@not-govuk/form-group': workspace:^0.3.0
       '@not-govuk/sass-base': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -1073,7 +1070,7 @@ importers:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/form-group': link:../form-group
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -1089,14 +1086,14 @@ importers:
       '@not-govuk/component-test-helpers': workspace:^0.3.0
       '@not-govuk/sass-base': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
     dependencies:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -1113,7 +1110,7 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/simple-table': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -1121,7 +1118,7 @@ importers:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
       '@not-govuk/simple-table': link:../../components-internal/simple-table
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -1140,7 +1137,7 @@ importers:
       '@not-govuk/table': workspace:^0.3.0
       '@not-govuk/tag': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -1148,7 +1145,7 @@ importers:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/route-utils': link:../../lib/route-utils
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -1167,14 +1164,14 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/table': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
     dependencies:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -1215,7 +1212,7 @@ importers:
       '@not-govuk/form-group': workspace:^0.3.0
       '@not-govuk/sass-base': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
@@ -1223,7 +1220,7 @@ importers:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/form-group': link:../form-group
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -1240,14 +1237,14 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/tag': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
     dependencies:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -1264,14 +1261,14 @@ importers:
       '@not-govuk/component-test-helpers': workspace:^0.3.0
       '@not-govuk/sass-base': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
     dependencies:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -1289,14 +1286,14 @@ importers:
       '@not-govuk/sass-base': workspace:^0.3.0
       '@not-govuk/tag': workspace:^0.3.0
       '@types/react': 16.14.24
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       jest: 26.6.3
       ts-jest: 26.5.6
       typescript: 3.9.10
     dependencies:
       '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/sass-base': link:../../lib-govuk/sass-base
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     devDependencies:
       '@mdx-js/react': 1.6.22_react@16.14.0
       '@not-govuk/component-test-helpers': link:../../lib/component-test-helpers
@@ -1328,9 +1325,9 @@ importers:
 
   lib-govuk/sass-base:
     specifiers:
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
     dependencies:
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
 
   lib/app-composer:
     specifiers:
@@ -1719,7 +1716,7 @@ importers:
       '@types/react-dom': 16.9.14
       '@types/react-router': 5.1.18
       '@types/react-router-dom': 5.3.3
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       typescript: 3.9.10
     dependencies:
       '@not-govuk/aside': link:../../components/aside
@@ -1765,7 +1762,7 @@ importers:
       '@types/react-dom': 16.9.14
       '@types/react-router': 5.1.18
       '@types/react-router-dom': 5.3.3
-      govuk-frontend: 3.9.1
+      govuk-frontend: 3.11.0
       typescript: 3.9.10
 
 packages:
@@ -6414,8 +6411,8 @@ packages:
     dependencies:
       anymatch: 3.1.2
 
-  /@types/aws-lambda/8.10.59:
-    resolution: {integrity: sha512-X/JclTKqHvo3nMTkHzClHhRz0yxn/VAr7J7LO6jBqaksZlhcDAWuU4oT1Yrt3E9MvX5jyyVIZtrwAI7oPXzXIg==}
+  /@types/aws-lambda/8.10.93:
+    resolution: {integrity: sha512-Vsyi9ogDAY3REZDjYnXMRJJa62SDvxHXxJI5nGDQdZW058dDE+av/anynN2rLKbCKXDRNw3D/sQmqxVflZFi4A==}
     requiresBuild: true
     dev: false
     optional: true
@@ -12528,8 +12525,8 @@ packages:
       url-parse-lax: 3.0.0
     dev: true
 
-  /govuk-frontend/3.9.1:
-    resolution: {integrity: sha512-ouOoDUj0QwDA4uCHIBkGCFMpORuTRcSuDscOrz7V1PBcOecntLglxJAZAuNm+j2sPo7anoScHU0ZSeE2QIoeAg==}
+  /govuk-frontend/3.11.0:
+    resolution: {integrity: sha512-1hW/3etYBtKPM+PNdWVOijvWVI3mpYL8eb7WLTtlh/Qxf2mCp6LkCsZk9I034n4EJBYQ5jlUWsUlTOOIypftpg==}
     engines: {node: '>= 4.2.0'}
 
   /graceful-fs/4.2.4:
@@ -12614,7 +12611,7 @@ packages:
       source-map: 0.6.1
       wordwrap: 1.0.0
     optionalDependencies:
-      uglify-js: 3.10.1
+      uglify-js: 3.15.3
 
   /har-schema/2.0.0:
     resolution: {integrity: sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=}
@@ -15832,7 +15829,7 @@ packages:
     dependencies:
       wildcard: 1.1.2
     optionalDependencies:
-      url-parse: 1.4.7
+      url-parse: 1.5.10
     dev: true
 
   /node-abi/2.30.1:
@@ -18776,7 +18773,7 @@ packages:
     resolution: {integrity: sha512-p0c1aTQ7mLZEtQkaP+K/zT4zFUY1YZs+mRlw/Q0yl+HptJL6IOLLylx6WXXFlQoH5+uUibivRzBbNotatvqDkg==}
     engines: {node: '>=8.0'}
     optionalDependencies:
-      '@types/aws-lambda': 8.10.59
+      '@types/aws-lambda': 8.10.93
     dev: false
 
   /serverless/2.72.3:
@@ -20277,8 +20274,8 @@ packages:
     hasBin: true
     dev: true
 
-  /uglify-js/3.10.1:
-    resolution: {integrity: sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==}
+  /uglify-js/3.15.3:
+    resolution: {integrity: sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==}
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true
@@ -20558,6 +20555,16 @@ packages:
     dependencies:
       querystringify: 2.1.1
       requires-port: 1.0.0
+    dev: false
+
+  /url-parse/1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+    requiresBuild: true
+    dependencies:
+      querystringify: 2.1.1
+      requires-port: 1.0.0
+    dev: true
+    optional: true
 
   /url/0.10.3:
     resolution: {integrity: sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=}


### PR DESCRIPTION
Sets the pinned version of govuk-frontend to always be v3.11.0 and removes the PNPM override.