### PR TITLE
webpack-config: Add support for private methods

### DIFF
--- a/lib/webpack-config/index.js
+++ b/lib/webpack-config/index.js
@@ -14,6 +14,7 @@ const babelPresetReact = require.resolve('@babel/preset-react');
 const babelPresetTypeScript = require.resolve('@babel/preset-typescript');
 const babelPluginExportNS = require.resolve('@babel/plugin-proposal-export-namespace-from');
 const babelPluginClassProperties = require.resolve('@babel/plugin-proposal-class-properties');
+const babelPluginPrivateMethods = require.resolve('@babel/plugin-proposal-private-methods');
 const cssLoader = require.resolve('css-loader');
 const fileLoader = require.resolve('file-loader');
 const htmlLoader = require.resolve('html-loader');
@@ -110,7 +111,8 @@ const generateConfig = (options) => {
         ],
         plugins: [
           [ babelPluginClassProperties, { loose: true } ],
-          babelPluginExportNS
+          babelPluginExportNS,
+          [ babelPluginPrivateMethods, { loose: true } ]
         ]
       }
     }

--- a/lib/webpack-config/package.json
+++ b/lib/webpack-config/package.json
@@ -14,6 +14,7 @@
     "@babel/core": "^7.10.2",
     "@babel/plugin-proposal-class-properties": "^7.10.4",
     "@babel/plugin-proposal-export-namespace-from": "^7.10.4",
+    "@babel/plugin-proposal-private-methods": "^7.10.4",
     "@babel/preset-env": "^7.10.2",
     "@babel/preset-react": "^7.10.1",
     "@babel/preset-typescript": "^7.10.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1628,6 +1628,7 @@ importers:
       '@babel/core': ^7.10.2
       '@babel/plugin-proposal-class-properties': ^7.10.4
       '@babel/plugin-proposal-export-namespace-from': ^7.10.4
+      '@babel/plugin-proposal-private-methods': ^7.10.4
       '@babel/preset-env': ^7.10.2
       '@babel/preset-react': ^7.10.1
       '@babel/preset-typescript': ^7.10.4
@@ -1651,6 +1652,7 @@ importers:
       '@babel/core': 7.10.5
       '@babel/plugin-proposal-class-properties': 7.10.4_@babel+core@7.10.5
       '@babel/plugin-proposal-export-namespace-from': 7.10.4_@babel+core@7.10.5
+      '@babel/plugin-proposal-private-methods': 7.16.11_@babel+core@7.10.5
       '@babel/preset-env': 7.10.4_@babel+core@7.10.5
       '@babel/preset-react': 7.10.4_@babel+core@7.10.5
       '@babel/preset-typescript': 7.10.4_@babel+core@7.10.5
@@ -1905,6 +1907,8 @@ packages:
       resolve: 1.17.0
       semver: 5.7.1
       source-map: 0.5.7
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/core/7.12.9:
@@ -1980,15 +1984,7 @@ packages:
   /@babel/generator/7.10.5:
     resolution: {integrity: sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==}
     dependencies:
-      '@babel/types': 7.10.5
-      jsesc: 2.5.2
-      source-map: 0.5.7
-    dev: false
-
-  /@babel/generator/7.11.4:
-    resolution: {integrity: sha512-Rn26vueFx0eOoz7iifCN2UHT6rGtnkSGWSoDRIy8jZN3B91PzeSULbswfLoOWuTuAcNwpG/mxy+uCTDnZ9Mp1g==}
-    dependencies:
-      '@babel/types': 7.11.0
+      '@babel/types': 7.17.0
       jsesc: 2.5.2
       source-map: 0.5.7
     dev: false
@@ -2009,26 +2005,20 @@ packages:
       '@babel/types': 7.17.0
       jsesc: 2.5.2
       source-map: 0.5.7
-    dev: true
-
-  /@babel/helper-annotate-as-pure/7.10.4:
-    resolution: {integrity: sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==}
-    dependencies:
-      '@babel/types': 7.10.5
-    dev: false
 
   /@babel/helper-annotate-as-pure/7.16.7:
     resolution: {integrity: sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.17.0
-    dev: true
 
   /@babel/helper-builder-binary-assignment-operator-visitor/7.10.4:
     resolution: {integrity: sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.10.4
-      '@babel/types': 7.10.5
+      '@babel/types': 7.17.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/helper-builder-binary-assignment-operator-visitor/7.16.7:
@@ -2042,16 +2032,16 @@ packages:
   /@babel/helper-builder-react-jsx-experimental/7.10.5:
     resolution: {integrity: sha512-Buewnx6M4ttG+NLkKyt7baQn7ScC/Td+e99G914fRU8fGIUivDDgVIQeDHFa5e4CRSJQt58WpNHhsAZgtzVhsg==}
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/helper-module-imports': 7.10.4
-      '@babel/types': 7.10.5
+      '@babel/types': 7.17.0
     dev: false
 
   /@babel/helper-builder-react-jsx/7.10.4:
     resolution: {integrity: sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==}
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.10.4
-      '@babel/types': 7.10.5
+      '@babel/helper-annotate-as-pure': 7.16.7
+      '@babel/types': 7.17.0
     dev: false
 
   /@babel/helper-compilation-targets/7.10.4_@babel+core@7.10.5:
@@ -2112,12 +2102,32 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-function-name': 7.10.4
-      '@babel/helper-member-expression-to-functions': 7.10.5
-      '@babel/helper-optimise-call-expression': 7.10.4
-      '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-replace-supers': 7.10.4
-      '@babel/helper-split-export-declaration': 7.10.4
+      '@babel/helper-function-name': 7.16.7
+      '@babel/helper-member-expression-to-functions': 7.16.7
+      '@babel/helper-optimise-call-expression': 7.16.7
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-replace-supers': 7.16.7
+      '@babel/helper-split-export-declaration': 7.16.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@babel/helper-create-class-features-plugin/7.17.6_@babel+core@7.10.5:
+    resolution: {integrity: sha512-SogLLSxXm2OkBbSsHZMM4tUi8fUzjs63AT/d0YQIzr6GSd8Hxsbk2KYDX0k0DweAzGMj/YWeiCsorIdtdcW8Eg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.10.5
+      '@babel/helper-annotate-as-pure': 7.16.7
+      '@babel/helper-environment-visitor': 7.16.7
+      '@babel/helper-function-name': 7.16.7
+      '@babel/helper-member-expression-to-functions': 7.16.7
+      '@babel/helper-optimise-call-expression': 7.16.7
+      '@babel/helper-replace-supers': 7.16.7
+      '@babel/helper-split-export-declaration': 7.16.7
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/helper-create-class-features-plugin/7.17.6_@babel+core@7.17.8:
@@ -2144,7 +2154,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/helper-regex': 7.10.5
       regexpu-core: 4.7.0
     dev: false
@@ -2163,8 +2173,8 @@ packages:
   /@babel/helper-define-map/7.10.5:
     resolution: {integrity: sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==}
     dependencies:
-      '@babel/helper-function-name': 7.10.4
-      '@babel/types': 7.10.5
+      '@babel/helper-function-name': 7.16.7
+      '@babel/types': 7.17.0
       lodash: 4.17.19
     dev: false
 
@@ -2191,13 +2201,14 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.17.0
-    dev: true
 
   /@babel/helper-explode-assignable-expression/7.10.4:
     resolution: {integrity: sha512-4K71RyRQNPRrR85sr5QY4X3VwG4wtVoXZB9+L3r1Gp38DhELyHCtovqydRi7c1Ovb17eRGiQ/FD5s8JdU0Uy5A==}
     dependencies:
-      '@babel/traverse': 7.10.5
-      '@babel/types': 7.10.5
+      '@babel/traverse': 7.17.3
+      '@babel/types': 7.17.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/helper-explode-assignable-expression/7.16.7:
@@ -2207,14 +2218,6 @@ packages:
       '@babel/types': 7.17.0
     dev: true
 
-  /@babel/helper-function-name/7.10.4:
-    resolution: {integrity: sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==}
-    dependencies:
-      '@babel/helper-get-function-arity': 7.10.4
-      '@babel/template': 7.10.4
-      '@babel/types': 7.12.1
-    dev: false
-
   /@babel/helper-function-name/7.16.7:
     resolution: {integrity: sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==}
     engines: {node: '>=6.9.0'}
@@ -2222,51 +2225,29 @@ packages:
       '@babel/helper-get-function-arity': 7.16.7
       '@babel/template': 7.16.7
       '@babel/types': 7.17.0
-    dev: true
-
-  /@babel/helper-get-function-arity/7.10.4:
-    resolution: {integrity: sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==}
-    dependencies:
-      '@babel/types': 7.12.1
-    dev: false
 
   /@babel/helper-get-function-arity/7.16.7:
     resolution: {integrity: sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.17.0
-    dev: true
-
-  /@babel/helper-hoist-variables/7.10.4:
-    resolution: {integrity: sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==}
-    dependencies:
-      '@babel/types': 7.10.5
-    dev: false
 
   /@babel/helper-hoist-variables/7.16.7:
     resolution: {integrity: sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.17.0
-    dev: true
-
-  /@babel/helper-member-expression-to-functions/7.10.5:
-    resolution: {integrity: sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==}
-    dependencies:
-      '@babel/types': 7.10.5
-    dev: false
 
   /@babel/helper-member-expression-to-functions/7.16.7:
     resolution: {integrity: sha512-VtJ/65tYiU/6AbMTDwyoXGPKHgTsfRarivm+YbB5uAzKUyuPjgZSgAFeG87FCigc7KNHu2Pegh1XIT3lXjvz3Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.17.0
-    dev: true
 
   /@babel/helper-module-imports/7.10.4:
     resolution: {integrity: sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==}
     dependencies:
-      '@babel/types': 7.10.5
+      '@babel/types': 7.17.0
     dev: false
 
   /@babel/helper-module-imports/7.16.7:
@@ -2280,12 +2261,14 @@ packages:
     resolution: {integrity: sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==}
     dependencies:
       '@babel/helper-module-imports': 7.10.4
-      '@babel/helper-replace-supers': 7.10.4
+      '@babel/helper-replace-supers': 7.16.7
       '@babel/helper-simple-access': 7.10.4
-      '@babel/helper-split-export-declaration': 7.10.4
-      '@babel/template': 7.10.4
-      '@babel/types': 7.10.5
+      '@babel/helper-split-export-declaration': 7.16.7
+      '@babel/template': 7.16.7
+      '@babel/types': 7.17.0
       lodash: 4.17.19
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/helper-module-transforms/7.17.7:
@@ -2304,18 +2287,11 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helper-optimise-call-expression/7.10.4:
-    resolution: {integrity: sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==}
-    dependencies:
-      '@babel/types': 7.12.1
-    dev: false
-
   /@babel/helper-optimise-call-expression/7.16.7:
     resolution: {integrity: sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.17.0
-    dev: true
 
   /@babel/helper-plugin-utils/7.10.4:
     resolution: {integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==}
@@ -2333,11 +2309,13 @@ packages:
   /@babel/helper-remap-async-to-generator/7.10.4:
     resolution: {integrity: sha512-86Lsr6NNw3qTNl+TBcF1oRZMaVzJtbWTyTko+CQL/tvNvcGYEFKbLXDPxtW0HKk3McNOk4KzY55itGWCAGK5tg==}
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/helper-wrap-function': 7.10.4
-      '@babel/template': 7.10.4
-      '@babel/traverse': 7.10.5
-      '@babel/types': 7.10.5
+      '@babel/template': 7.16.7
+      '@babel/traverse': 7.17.3
+      '@babel/types': 7.17.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/helper-remap-async-to-generator/7.16.8:
@@ -2351,15 +2329,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helper-replace-supers/7.10.4:
-    resolution: {integrity: sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==}
-    dependencies:
-      '@babel/helper-member-expression-to-functions': 7.10.5
-      '@babel/helper-optimise-call-expression': 7.10.4
-      '@babel/traverse': 7.10.5
-      '@babel/types': 7.10.5
-    dev: false
-
   /@babel/helper-replace-supers/7.16.7:
     resolution: {integrity: sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==}
     engines: {node: '>=6.9.0'}
@@ -2371,13 +2340,12 @@ packages:
       '@babel/types': 7.17.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-simple-access/7.10.4:
     resolution: {integrity: sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==}
     dependencies:
-      '@babel/template': 7.10.4
-      '@babel/types': 7.10.5
+      '@babel/template': 7.16.7
+      '@babel/types': 7.17.0
     dev: false
 
   /@babel/helper-simple-access/7.17.7:
@@ -2394,24 +2362,11 @@ packages:
       '@babel/types': 7.17.0
     dev: true
 
-  /@babel/helper-split-export-declaration/7.10.4:
-    resolution: {integrity: sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==}
-    dependencies:
-      '@babel/types': 7.10.5
-    dev: false
-
-  /@babel/helper-split-export-declaration/7.11.0:
-    resolution: {integrity: sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==}
-    dependencies:
-      '@babel/types': 7.12.6
-    dev: false
-
   /@babel/helper-split-export-declaration/7.16.7:
     resolution: {integrity: sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.17.0
-    dev: true
 
   /@babel/helper-validator-identifier/7.16.7:
     resolution: {integrity: sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==}
@@ -2425,10 +2380,12 @@ packages:
   /@babel/helper-wrap-function/7.10.4:
     resolution: {integrity: sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==}
     dependencies:
-      '@babel/helper-function-name': 7.10.4
-      '@babel/template': 7.10.4
-      '@babel/traverse': 7.10.5
-      '@babel/types': 7.10.5
+      '@babel/helper-function-name': 7.16.7
+      '@babel/template': 7.16.7
+      '@babel/traverse': 7.17.3
+      '@babel/types': 7.17.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/helper-wrap-function/7.16.8:
@@ -2446,9 +2403,11 @@ packages:
   /@babel/helpers/7.10.4:
     resolution: {integrity: sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==}
     dependencies:
-      '@babel/template': 7.10.4
-      '@babel/traverse': 7.11.0
-      '@babel/types': 7.11.0
+      '@babel/template': 7.16.7
+      '@babel/traverse': 7.17.3
+      '@babel/types': 7.17.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/helpers/7.17.7:
@@ -2487,18 +2446,6 @@ packages:
     hasBin: true
     dev: false
 
-  /@babel/parser/7.11.4:
-    resolution: {integrity: sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dev: false
-
-  /@babel/parser/7.12.5:
-    resolution: {integrity: sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dev: false
-
   /@babel/parser/7.17.3:
     resolution: {integrity: sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==}
     engines: {node: '>=6.0.0'}
@@ -2509,7 +2456,6 @@ packages:
     resolution: {integrity: sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-    dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.16.7_@babel+core@7.17.8:
     resolution: {integrity: sha512-anv/DObl7waiGEnC24O9zqL0pSuI9hljihqiDuFHC8d7/bjr/4RLGPWuc8rYOff/QPzbEPSkzG8wGG9aDuhHRg==}
@@ -2539,9 +2485,11 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       '@babel/helper-remap-async-to-generator': 7.10.4
       '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.10.5
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-proposal-async-generator-functions/7.16.8_@babel+core@7.17.8:
@@ -2566,6 +2514,8 @@ packages:
       '@babel/core': 7.10.5
       '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.10.5
       '@babel/helper-plugin-utils': 7.10.4
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-proposal-class-properties/7.16.7_@babel+core@7.17.8:
@@ -2617,7 +2567,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.10.5
     dev: false
 
@@ -2670,7 +2620,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.10.5
     dev: false
 
@@ -2702,7 +2652,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.10.5
     dev: false
 
@@ -2723,7 +2673,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.10.5
     dev: false
 
@@ -2744,7 +2694,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.10.5
       '@babel/plugin-transform-parameters': 7.10.5_@babel+core@7.10.5
     dev: false
@@ -2780,7 +2730,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.10.5
     dev: false
 
@@ -2801,7 +2751,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.10.5
     dev: false
 
@@ -2817,14 +2767,17 @@ packages:
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.17.8
     dev: true
 
-  /@babel/plugin-proposal-private-methods/7.10.4_@babel+core@7.10.5:
-    resolution: {integrity: sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==}
+  /@babel/plugin-proposal-private-methods/7.16.11_@babel+core@7.10.5:
+    resolution: {integrity: sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==}
+    engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-create-class-features-plugin': 7.17.6_@babel+core@7.10.5
+      '@babel/helper-plugin-utils': 7.16.7
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-proposal-private-methods/7.16.11_@babel+core@7.17.8:
@@ -2863,7 +2816,7 @@ packages:
     dependencies:
       '@babel/core': 7.10.5
       '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-proposal-unicode-property-regex/7.16.7_@babel+core@7.17.8:
@@ -2910,7 +2863,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.17.8:
@@ -2948,7 +2901,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.17.8:
@@ -2957,7 +2910,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
   /@babel/plugin-syntax-export-default-from/7.16.7_@babel+core@7.17.8:
@@ -2976,7 +2929,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.17.8:
@@ -2985,7 +2938,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.17.8
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: true
 
   /@babel/plugin-syntax-flow/7.16.7_@babel+core@7.17.8:
@@ -3031,7 +2984,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-syntax-jsx/7.12.1_@babel+core@7.12.9:
@@ -3177,7 +3130,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.17.8:
@@ -3196,7 +3149,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-syntax-typescript/7.16.7_@babel+core@7.17.8:
@@ -3215,7 +3168,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-arrow-functions/7.16.7_@babel+core@7.17.8:
@@ -3235,8 +3188,10 @@ packages:
     dependencies:
       '@babel/core': 7.10.5
       '@babel/helper-module-imports': 7.10.4
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       '@babel/helper-remap-async-to-generator': 7.10.4
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-transform-async-to-generator/7.16.8_@babel+core@7.17.8:
@@ -3259,7 +3214,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-block-scoped-functions/7.16.7_@babel+core@7.17.8:
@@ -3278,7 +3233,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-block-scoping/7.16.7_@babel+core@7.17.8:
@@ -3297,14 +3252,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-annotate-as-pure': 7.16.7
       '@babel/helper-define-map': 7.10.5
-      '@babel/helper-function-name': 7.10.4
-      '@babel/helper-optimise-call-expression': 7.10.4
-      '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-replace-supers': 7.10.4
-      '@babel/helper-split-export-declaration': 7.10.4
+      '@babel/helper-function-name': 7.16.7
+      '@babel/helper-optimise-call-expression': 7.16.7
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-replace-supers': 7.16.7
+      '@babel/helper-split-export-declaration': 7.16.7
       globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-transform-classes/7.16.7_@babel+core@7.17.8:
@@ -3332,7 +3289,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-computed-properties/7.16.7_@babel+core@7.17.8:
@@ -3351,7 +3308,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-destructuring/7.17.3_@babel+core@7.17.8:
@@ -3371,7 +3328,7 @@ packages:
     dependencies:
       '@babel/core': 7.10.5
       '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-dotall-regex/7.16.7_@babel+core@7.17.8:
@@ -3391,7 +3348,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-duplicate-keys/7.16.7_@babel+core@7.17.8:
@@ -3411,7 +3368,9 @@ packages:
     dependencies:
       '@babel/core': 7.10.5
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.10.4
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-transform-exponentiation-operator/7.16.7_@babel+core@7.17.8:
@@ -3442,7 +3401,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-for-of/7.16.7_@babel+core@7.17.8:
@@ -3461,8 +3420,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-function-name': 7.10.4
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-function-name': 7.16.7
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-function-name/7.16.7_@babel+core@7.17.8:
@@ -3483,7 +3442,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-literals/7.16.7_@babel+core@7.17.8:
@@ -3502,7 +3461,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-member-expression-literals/7.16.7_@babel+core@7.17.8:
@@ -3522,8 +3481,10 @@ packages:
     dependencies:
       '@babel/core': 7.10.5
       '@babel/helper-module-transforms': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       babel-plugin-dynamic-import-node: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-transform-modules-amd/7.16.7_@babel+core@7.17.8:
@@ -3547,9 +3508,11 @@ packages:
     dependencies:
       '@babel/core': 7.10.5
       '@babel/helper-module-transforms': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       '@babel/helper-simple-access': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-transform-modules-commonjs/7.16.8_@babel+core@7.17.8:
@@ -3573,10 +3536,12 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-hoist-variables': 7.10.4
+      '@babel/helper-hoist-variables': 7.16.7
       '@babel/helper-module-transforms': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       babel-plugin-dynamic-import-node: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-transform-modules-systemjs/7.16.7_@babel+core@7.17.8:
@@ -3602,7 +3567,9 @@ packages:
     dependencies:
       '@babel/core': 7.10.5
       '@babel/helper-module-transforms': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-transform-modules-umd/7.16.7_@babel+core@7.17.8:
@@ -3643,7 +3610,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-new-target/7.16.7_@babel+core@7.17.8:
@@ -3662,8 +3629,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-replace-supers': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
+      '@babel/helper-replace-supers': 7.16.7
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-transform-object-super/7.16.7_@babel+core@7.17.8:
@@ -3685,8 +3654,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-get-function-arity': 7.10.4
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-get-function-arity': 7.16.7
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-parameters/7.16.7_@babel+core@7.12.9:
@@ -3715,7 +3684,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-property-literals/7.16.7_@babel+core@7.17.8:
@@ -3744,7 +3713,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-react-display-name/7.16.7_@babel+core@7.17.8:
@@ -3764,7 +3733,7 @@ packages:
     dependencies:
       '@babel/core': 7.10.5
       '@babel/helper-builder-react-jsx-experimental': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.10.5
     dev: false
 
@@ -3784,7 +3753,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.10.5
     dev: false
 
@@ -3794,7 +3763,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.10.5
     dev: false
 
@@ -3806,7 +3775,7 @@ packages:
       '@babel/core': 7.10.5
       '@babel/helper-builder-react-jsx': 7.10.4
       '@babel/helper-builder-react-jsx-experimental': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.10.5
     dev: false
 
@@ -3830,8 +3799,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-annotate-as-pure': 7.10.4
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-annotate-as-pure': 7.16.7
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-react-pure-annotations/7.16.7_@babel+core@7.17.8:
@@ -3870,7 +3839,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-reserved-words/7.16.7_@babel+core@7.17.8:
@@ -3889,7 +3858,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-shorthand-properties/7.16.7_@babel+core@7.17.8:
@@ -3908,7 +3877,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-spread/7.16.7_@babel+core@7.17.8:
@@ -3928,7 +3897,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       '@babel/helper-regex': 7.10.5
     dev: false
 
@@ -3948,8 +3917,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-annotate-as-pure': 7.10.4
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-annotate-as-pure': 7.16.7
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-template-literals/7.16.7_@babel+core@7.17.8:
@@ -3968,7 +3937,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-typeof-symbol/7.16.7_@babel+core@7.17.8:
@@ -3987,9 +3956,11 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-create-class-features-plugin': 7.17.6_@babel+core@7.10.5
+      '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-syntax-typescript': 7.10.4_@babel+core@7.10.5
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-transform-typescript/7.16.8_@babel+core@7.17.8:
@@ -4012,7 +3983,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-unicode-escapes/7.16.7_@babel+core@7.17.8:
@@ -4032,7 +4003,7 @@ packages:
     dependencies:
       '@babel/core': 7.10.5
       '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
   /@babel/plugin-transform-unicode-regex/7.16.7_@babel+core@7.17.8:
@@ -4065,7 +4036,7 @@ packages:
       '@babel/plugin-proposal-object-rest-spread': 7.10.4_@babel+core@7.10.5
       '@babel/plugin-proposal-optional-catch-binding': 7.10.4_@babel+core@7.10.5
       '@babel/plugin-proposal-optional-chaining': 7.10.4_@babel+core@7.10.5
-      '@babel/plugin-proposal-private-methods': 7.10.4_@babel+core@7.10.5
+      '@babel/plugin-proposal-private-methods': 7.16.11_@babel+core@7.10.5
       '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.10.5
       '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.10.5
       '@babel/plugin-syntax-class-properties': 7.10.4_@babel+core@7.10.5
@@ -4116,6 +4087,8 @@ packages:
       invariant: 2.2.4
       levenary: 1.1.1
       semver: 5.7.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/preset-env/7.16.11_@babel+core@7.17.8:
@@ -4221,10 +4194,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.16.7
       '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.10.5
       '@babel/plugin-transform-dotall-regex': 7.10.4_@babel+core@7.10.5
-      '@babel/types': 7.10.5
+      '@babel/types': 7.17.0
       esutils: 2.0.3
     dev: false
 
@@ -4279,6 +4252,8 @@ packages:
       '@babel/core': 7.10.5
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-transform-typescript': 7.10.5_@babel+core@7.10.5
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/preset-typescript/7.16.7_@babel+core@7.17.8:
@@ -4325,8 +4300,8 @@ packages:
     resolution: {integrity: sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==}
     dependencies:
       '@babel/code-frame': 7.16.7
-      '@babel/parser': 7.12.5
-      '@babel/types': 7.12.6
+      '@babel/parser': 7.17.8
+      '@babel/types': 7.17.0
     dev: false
 
   /@babel/template/7.16.7:
@@ -4336,34 +4311,21 @@ packages:
       '@babel/code-frame': 7.16.7
       '@babel/parser': 7.17.8
       '@babel/types': 7.17.0
-    dev: true
 
   /@babel/traverse/7.10.5:
     resolution: {integrity: sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==}
     dependencies:
       '@babel/code-frame': 7.16.7
-      '@babel/generator': 7.10.5
-      '@babel/helper-function-name': 7.10.4
-      '@babel/helper-split-export-declaration': 7.10.4
-      '@babel/parser': 7.10.5
-      '@babel/types': 7.10.5
-      debug: 4.1.1
+      '@babel/generator': 7.17.7
+      '@babel/helper-function-name': 7.16.7
+      '@babel/helper-split-export-declaration': 7.16.7
+      '@babel/parser': 7.17.8
+      '@babel/types': 7.17.0
+      debug: 4.3.3
       globals: 11.12.0
       lodash: 4.17.19
-    dev: false
-
-  /@babel/traverse/7.11.0:
-    resolution: {integrity: sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==}
-    dependencies:
-      '@babel/code-frame': 7.16.7
-      '@babel/generator': 7.11.4
-      '@babel/helper-function-name': 7.10.4
-      '@babel/helper-split-export-declaration': 7.11.0
-      '@babel/parser': 7.11.4
-      '@babel/types': 7.11.0
-      debug: 4.1.1
-      globals: 11.12.0
-      lodash: 4.17.20
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/traverse/7.17.3:
@@ -4382,7 +4344,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/types/7.10.5:
     resolution: {integrity: sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==}
@@ -4392,37 +4353,12 @@ packages:
       to-fast-properties: 2.0.0
     dev: false
 
-  /@babel/types/7.11.0:
-    resolution: {integrity: sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.16.7
-      lodash: 4.17.20
-      to-fast-properties: 2.0.0
-    dev: false
-
-  /@babel/types/7.12.1:
-    resolution: {integrity: sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.16.7
-      lodash: 4.17.20
-      to-fast-properties: 2.0.0
-    dev: false
-
-  /@babel/types/7.12.6:
-    resolution: {integrity: sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.16.7
-      lodash: 4.17.20
-      to-fast-properties: 2.0.0
-    dev: false
-
   /@babel/types/7.17.0:
     resolution: {integrity: sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-validator-identifier': 7.16.7
       to-fast-properties: 2.0.0
-    dev: true
 
   /@base2/pretty-print-object/1.0.1:
     resolution: {integrity: sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==}
@@ -4920,6 +4856,7 @@ packages:
       loader-utils: 2.0.0
     transitivePeerDependencies:
       - react
+      - supports-color
     dev: false
 
   /@mdx-js/loader/1.6.22_react@16.14.0:
@@ -4955,6 +4892,8 @@ packages:
       unified: 9.0.0
       unist-builder: 2.0.3
       unist-util-visit: 2.0.3
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@mdx-js/mdx/1.6.22:
@@ -9464,7 +9403,7 @@ packages:
   /debug/4.1.1:
     resolution: {integrity: sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==}
     dependencies:
-      ms: 2.1.2
+      ms: 2.1.3
     dev: false
 
   /debug/4.3.2:
@@ -9488,7 +9427,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
 
   /debug/4.3.3_supports-color@8.1.1:
     resolution: {integrity: sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==}
@@ -11078,6 +11016,7 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: true
 
   /follow-redirects/1.14.9_debug@4.3.2:
     resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}
@@ -11089,7 +11028,6 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.2
-    dev: true
 
   /for-in/1.0.2:
     resolution: {integrity: sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=}
@@ -12186,7 +12124,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.5
-      follow-redirects: 1.14.9
+      follow-redirects: 1.14.9_debug@4.3.2
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -14124,10 +14062,6 @@ packages:
   /lodash/4.17.19:
     resolution: {integrity: sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==}
 
-  /lodash/4.17.20:
-    resolution: {integrity: sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==}
-    dev: false
-
   /lodash/4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
@@ -14711,7 +14645,6 @@ packages:
 
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-    dev: true
 
   /mute-stream/0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
@@ -16788,6 +16721,8 @@ packages:
       is-alphabetical: 1.0.4
       remark-parse: 8.0.2
       unified: 9.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /remark-mdx/1.6.22:


### PR DESCRIPTION
This is required for the latest version of openid-client.