### PR TITLE
plop-pack: Avoid running on Node.js v16

### DIFF
--- a/apps/govuk-docs/package.json
+++ b/apps/govuk-docs/package.json
@@ -25,7 +25,7 @@
   "author": "Daniel A.C. Martin <npm@daniel-martin.co.uk> (http://daniel-martin.co.uk/)",
   "license": "MIT",
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=14.0.0 <15",
     "os": [
       "darwin",
       "linux"

--- a/apps/govuk-template/package.json
+++ b/apps/govuk-template/package.json
@@ -25,7 +25,7 @@
   "author": "Daniel A.C. Martin <npm@daniel-martin.co.uk> (http://daniel-martin.co.uk/)",
   "license": "MIT",
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=14.0.0 <15",
     "os": [
       "darwin",
       "linux"

--- a/lib/plop-pack/skel/app/package.json.hbs
+++ b/lib/plop-pack/skel/app/package.json.hbs
@@ -25,7 +25,7 @@
   "author": "{{{pkg 'author'}}}",
   "license": "{{{pkg 'license'}}}",
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=14.0.0 <15",
     "os": [
       "darwin",
       "linux"


### PR DESCRIPTION
We don't support this due to our current use of fibres.