### PR TITLE
sass-base: Set the asset path to be relative

### DIFF
--- a/components/footer/assets/Footer.scss
+++ b/components/footer/assets/Footer.scss
@@ -2,10 +2,6 @@
 @import "govuk-frontend/govuk/components/footer/_index";
 
 .govuk-footer {
-  &__copyright-logo {
-    background-image: url('~govuk-frontend/govuk/assets/images/govuk-crest.png') !important; // TODO: !important is required due to SCSS being included twice.
-  }
-
   .govuk-link, a {
     @extend .govuk-footer__link;
   }

--- a/lib-govuk/sass-base/src/index.scss
+++ b/lib-govuk/sass-base/src/index.scss
@@ -8,6 +8,9 @@ $govuk-font-family: inherit;
 $govuk-text-colour: inherit;
 $govuk-link-active-colour: inherit;
 
+// Set the asset path to be relative to the SCSS components
+$govuk-assets-path: '../../assets/';
+
 @import "govuk-frontend/govuk/_base";
 
 // Dark mode variables


### PR DESCRIPTION
This should allow webpack to find the files and eliminate the need for
overrides.