### PR TITLE
engine: Make readiness function optional

### DIFF
--- a/lib/engine/src/index.ts
+++ b/lib/engine/src/index.ts
@@ -66,7 +66,7 @@ export type EngineStage2Options = {
   graphQL?: {
     schema: GraphQLSchema
   }
-  isReady: IsReady
+  isReady?: IsReady
   privacy?: boolean
   pageLoader: PageLoader
 };


### PR DESCRIPTION
This should avoid a breaking change for the time-being.