### PR TITLE
More standard component documentation

### DIFF
--- a/components-internal/anchor-list/package.json
+++ b/components-internal/anchor-list/package.json
@@ -29,8 +29,17 @@
     "@not-govuk/route-utils": "workspace:^0.4.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components-internal/anchor-list/spec/AnchorList.stories.mdx
+++ b/components-internal/anchor-list/spec/AnchorList.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { AnchorList } from '../src/AnchorList';
 import readMe from '../README.md';
 export const title = 'Anchor list';

--- a/components-internal/anchor/package.json
+++ b/components-internal/anchor/package.json
@@ -29,8 +29,17 @@
     "react-router-hash-link": "^2.4.3"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components-internal/anchor/spec/Anchor.stories.mdx
+++ b/components-internal/anchor/spec/Anchor.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { A } from '../src/Anchor';
 import readMe from '../README.md';
 export const title = 'Anchor';

--- a/components-internal/simple-table/package.json
+++ b/components-internal/simple-table/package.json
@@ -27,8 +27,17 @@
     "@not-govuk/component-helpers": "workspace:^0.4.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components-internal/simple-table/spec/SimpleTable.stories.mdx
+++ b/components-internal/simple-table/spec/SimpleTable.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { SimpleTable } from '../src/SimpleTable';
 import readMe from '../README.md';
 export const title = 'SimpleTable';

--- a/components-internal/tabs/package.json
+++ b/components-internal/tabs/package.json
@@ -28,8 +28,17 @@
     "@not-govuk/route-utils": "workspace:^0.4.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components-internal/tabs/spec/Tabs.stories.mdx
+++ b/components-internal/tabs/spec/Tabs.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Tabs } from '../src/Tabs';
 import readMe from '../README.md';
 

--- a/components/aside/package.json
+++ b/components/aside/package.json
@@ -29,8 +29,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/aside/spec/Aside.stories.mdx
+++ b/components/aside/spec/Aside.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Tag } from '@not-govuk/tag';
 import { Aside } from '../src/Aside';
 import readMe from '../README.md';

--- a/components/back-link/package.json
+++ b/components/back-link/package.json
@@ -30,8 +30,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/back-link/spec/BackLink.stories.mdx
+++ b/components/back-link/spec/BackLink.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { BackLink } from '../src/BackLink';
 import readMe from '../README.md';
 

--- a/components/breadcrumbs/package.json
+++ b/components/breadcrumbs/package.json
@@ -30,8 +30,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/breadcrumbs/spec/Breadcrumbs.stories.mdx
+++ b/components/breadcrumbs/spec/Breadcrumbs.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Breadcrumbs } from '../src/Breadcrumbs';
 import readMe from '../README.md';
 

--- a/components/button-group/package.json
+++ b/components/button-group/package.json
@@ -29,8 +29,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
     "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/button-group/spec/ButtonGroup.stories.mdx
+++ b/components/button-group/spec/ButtonGroup.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { A } from '@not-govuk/link';
 import { Tag } from '@not-govuk/tag';
 import { ButtonGroup } from '../src/ButtonGroup';

--- a/components/button/package.json
+++ b/components/button/package.json
@@ -30,8 +30,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
     "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/button/spec/Button.stories.mdx
+++ b/components/button/spec/Button.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { ButtonGroup } from '@not-govuk/button-group';
 import { A } from '@not-govuk/link';
 import { Tag } from '@not-govuk/tag';

--- a/components/checkboxes/package.json
+++ b/components/checkboxes/package.json
@@ -32,8 +32,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.14.0"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/checkboxes/spec/Checkboxes.stories.mdx
+++ b/components/checkboxes/spec/Checkboxes.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { TextInput } from '@not-govuk/text-input';
 import { Checkboxes } from '../src/Checkboxes';
 import readMe from '../README.md';

--- a/components/cookie-banner/package.json
+++ b/components/cookie-banner/package.json
@@ -31,8 +31,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.3.0",
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
     "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/cookie-banner/spec/CookieBanner.stories.mdx
+++ b/components/cookie-banner/spec/CookieBanner.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Button } from '@not-govuk/button';
 import { A } from '@not-govuk/link';
 import { Tag } from '@not-govuk/tag';

--- a/components/cookie-banner/spec/CookieBanner.stories.mdx
+++ b/components/cookie-banner/spec/CookieBanner.stories.mdx
@@ -1,3 +1,4 @@
+import { Fragment } from 'react';
 import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Button } from '@not-govuk/button';
 import { A } from '@not-govuk/link';

--- a/components/date-input/package.json
+++ b/components/date-input/package.json
@@ -32,8 +32,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
     "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/date-input/spec/DateInput.stories.mdx
+++ b/components/date-input/spec/DateInput.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { DateInput } from '../src/DateInput';
 import readMe from '../README.md';
 

--- a/components/details/package.json
+++ b/components/details/package.json
@@ -29,8 +29,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/details/spec/Details.stories.mdx
+++ b/components/details/spec/Details.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Details } from '../src/Details';
 import readMe from '../README.md';
 

--- a/components/error-message/package.json
+++ b/components/error-message/package.json
@@ -30,8 +30,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/error-message/spec/ErrorMessage.stories.mdx
+++ b/components/error-message/spec/ErrorMessage.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { ErrorMessage } from '../src/ErrorMessage';
 import readMe from '../README.md';
 

--- a/components/fieldset/package.json
+++ b/components/fieldset/package.json
@@ -29,8 +29,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/fieldset/spec/FieldSet.stories.mdx
+++ b/components/fieldset/spec/FieldSet.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Input } from '@not-govuk/input';
 import { Label } from '@not-govuk/label';
 import { VisuallyHidden } from '@not-govuk/visually-hidden';

--- a/components/footer/package.json
+++ b/components/footer/package.json
@@ -31,8 +31,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/footer/spec/Footer.stories.mdx
+++ b/components/footer/spec/Footer.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { A } from '@not-govuk/link';
 import { Footer } from '../src/Footer';
 import readMe from '../README.md';

--- a/components/form-field/package.json
+++ b/components/form-field/package.json
@@ -24,8 +24,17 @@
     "react-components"
   ],
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
     "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/form-field/spec/FormField.stories.mdx
+++ b/components/form-field/spec/FormField.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Tag } from '@not-govuk/tag';
 import { FormField } from '../src/FormField';
 import readMe from '../README.md';

--- a/components/form-group/package.json
+++ b/components/form-group/package.json
@@ -33,8 +33,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.14.0"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/form-group/spec/FormGroup.stories.mdx
+++ b/components/form-group/spec/FormGroup.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Tag } from '@not-govuk/tag';
 import { FormGroup } from '../src/FormGroup';
 import readMe from '../README.md';

--- a/components/form/package.json
+++ b/components/form/package.json
@@ -36,8 +36,17 @@
     "@not-govuk/textarea": "workspace:^0.4.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/form/spec/Form.stories.mdx
+++ b/components/form/spec/Form.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Tag } from '@not-govuk/tag';
 import { Form, after, past, required } from '../src/Form';
 import readMe from '../README.md';

--- a/components/header/package.json
+++ b/components/header/package.json
@@ -31,8 +31,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/header/spec/Header.stories.mdx
+++ b/components/header/spec/Header.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Header } from '../src/Header';
 import readMe from '../README.md';
 

--- a/components/hint/package.json
+++ b/components/hint/package.json
@@ -29,8 +29,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/hint/spec/Hint.stories.mdx
+++ b/components/hint/spec/Hint.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Tag } from '@not-govuk/tag';
 import { Hint } from '../src/Hint';
 import readMe from '../README.md';

--- a/components/input/package.json
+++ b/components/input/package.json
@@ -29,8 +29,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
     "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/input/spec/Input.stories.mdx
+++ b/components/input/spec/Input.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Tag } from '@not-govuk/tag';
 import { Input } from '../src/Input';
 import readMe from '../README.md';

--- a/components/inset-text/package.json
+++ b/components/inset-text/package.json
@@ -29,8 +29,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/inset-text/spec/InsetText.stories.mdx
+++ b/components/inset-text/spec/InsetText.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { InsetText } from '../src/InsetText';
 import readMe from '../README.md';
 

--- a/components/label/package.json
+++ b/components/label/package.json
@@ -29,8 +29,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/label/spec/Label.stories.mdx
+++ b/components/label/spec/Label.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Tag } from '@not-govuk/tag';
 import { Label } from '../src/Label';
 import readMe from '../README.md';

--- a/components/link/package.json
+++ b/components/link/package.json
@@ -29,8 +29,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/link/spec/Link.stories.mdx
+++ b/components/link/spec/Link.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Tag } from '@not-govuk/tag';
 import { A } from '../src/Link';
 import readMe from '../README.md';

--- a/components/navigation-menu/package.json
+++ b/components/navigation-menu/package.json
@@ -30,8 +30,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/navigation-menu/spec/NavigationMenu.stories.mdx
+++ b/components/navigation-menu/spec/NavigationMenu.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Tag } from '@not-govuk/tag';
 import { NavigationMenu } from '../src/NavigationMenu';
 import readMe from '../README.md';

--- a/components/page/package.json
+++ b/components/page/package.json
@@ -37,9 +37,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35",
-    "react-helmet-async": "^1.0.7"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/page/spec/Page.stories.mdx
+++ b/components/page/spec/Page.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Tag } from '@not-govuk/tag';
 import { Aside } from '@not-govuk/aside';
 import { GovUKPage, NotGovUKPage, Page } from '../src';

--- a/components/panel/package.json
+++ b/components/panel/package.json
@@ -29,8 +29,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/panel/spec/Panel.stories.mdx
+++ b/components/panel/spec/Panel.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Panel } from '../src/Panel';
 import readMe from '../README.md';
 

--- a/components/phase-banner/package.json
+++ b/components/phase-banner/package.json
@@ -30,8 +30,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/phase-banner/spec/PhaseBanner.stories.mdx
+++ b/components/phase-banner/spec/PhaseBanner.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { PhaseBanner } from '../src/PhaseBanner';
 import readMe from '../README.md';
 

--- a/components/radios/package.json
+++ b/components/radios/package.json
@@ -32,8 +32,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
     "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/radios/spec/Radios.stories.mdx
+++ b/components/radios/spec/Radios.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { TextInput } from '@not-govuk/text-input';
 import { Radios } from '../src/Radios';
 import readMe from '../README.md';

--- a/components/select/package.json
+++ b/components/select/package.json
@@ -30,8 +30,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
     "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/select/spec/Select.stories.mdx
+++ b/components/select/spec/Select.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Select } from '../src/Select';
 import readMe from '../README.md';
 

--- a/components/skip-link/package.json
+++ b/components/skip-link/package.json
@@ -29,8 +29,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/skip-link/spec/SkipLink.stories.mdx
+++ b/components/skip-link/spec/SkipLink.stories.mdx
@@ -1,5 +1,5 @@
 import { Fragment } from 'react';
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { SkipLink } from '../src/SkipLink';
 import readMe from '../README.md';
 

--- a/components/table/package.json
+++ b/components/table/package.json
@@ -30,8 +30,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/table/spec/Table.stories.mdx
+++ b/components/table/spec/Table.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Table } from '../src/Table';
 import readMe from '../README.md';
 

--- a/components/tabs/package.json
+++ b/components/tabs/package.json
@@ -30,8 +30,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/tabs/spec/Tabs.stories.mdx
+++ b/components/tabs/spec/Tabs.stories.mdx
@@ -1,5 +1,5 @@
 import { Fragment } from 'react';
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Tag } from '@not-govuk/tag';
 import { Table } from '@not-govuk/table';
 import { Tabs } from '../src/Tabs';

--- a/components/tag/package.json
+++ b/components/tag/package.json
@@ -29,8 +29,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/tag/spec/Tag.stories.mdx
+++ b/components/tag/spec/Tag.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Table } from '@not-govuk/table';
 import { Tag } from '../src/Tag';
 import readMe from '../README.md';

--- a/components/text-input/package.json
+++ b/components/text-input/package.json
@@ -29,8 +29,17 @@
     "@not-govuk/input": "workspace:^0.4.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/text-input/spec/TextInput.stories.mdx
+++ b/components/text-input/spec/TextInput.stories.mdx
@@ -1,5 +1,5 @@
 import { Fragment } from 'react';
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { TextInput } from '../src/TextInput';
 import readMe from '../README.md';
 

--- a/components/text-input/spec/TextInput.stories.mdx
+++ b/components/text-input/spec/TextInput.stories.mdx
@@ -1,4 +1,3 @@
-import { Fragment } from 'react';
 import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { TextInput } from '../src/TextInput';
 import readMe from '../README.md';

--- a/components/textarea/package.json
+++ b/components/textarea/package.json
@@ -30,8 +30,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
     "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/textarea/spec/Textarea.stories.mdx
+++ b/components/textarea/spec/Textarea.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Textarea } from '../src/Textarea';
 import readMe from '../README.md';
 

--- a/components/visually-hidden/package.json
+++ b/components/visually-hidden/package.json
@@ -29,8 +29,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/visually-hidden/spec/VisuallyHidden.stories.mdx
+++ b/components/visually-hidden/spec/VisuallyHidden.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Tag } from '@not-govuk/tag';
 import { VisuallyHidden } from '../src/VisuallyHidden';
 import readMe from '../README.md';

--- a/components/warning-text/package.json
+++ b/components/warning-text/package.json
@@ -29,8 +29,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/warning-text/spec/WarningText.stories.mdx
+++ b/components/warning-text/spec/WarningText.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { WarningText } from '../src/WarningText';
 import readMe from '../README.md';
 

--- a/components/width-container/package.json
+++ b/components/width-container/package.json
@@ -29,8 +29,17 @@
     "govuk-frontend": "3.11.0"
   },
   "peerDependencies": {
-    "@not-govuk/docs-components": "^0.2.0 || ^0.3.0",
-    "react": "^16.9.35"
+    "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
+    "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/components/width-container/spec/WidthContainer.stories.mdx
+++ b/components/width-container/spec/WidthContainer.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { Panel } from '@not-govuk/panel';
 import { Tag } from '@not-govuk/tag';
 import { WidthContainer } from '../src/WidthContainer';

--- a/lib/docs-components/src/Props.tsx
+++ b/lib/docs-components/src/Props.tsx
@@ -1,8 +1,8 @@
 import { ComponentType, FC, createElement as h } from 'react';
-import { Props as _Props } from '@storybook/addon-docs/blocks';
 import { extractArgTypes } from '@storybook/addon-docs/dist/frameworks/react/extractArgTypes';
 import { SimpleTable } from '@not-govuk/simple-table';
-import { inStorybook } from './common';
+
+import type { Props as _Props } from '@storybook/addon-docs/blocks';
 
 type PropsTableRow = {
   default: string
@@ -30,26 +30,22 @@ export const Props: FC<PropsProps> = (props) => {
       });
     });
 
-  return (
-    inStorybook
-      ? h(_Props, props)
-      : h(
-        'details', {},
-        [
-          h('summary', { key: 0 }, 'Props'),
-          h(
-            SimpleTable, {
-              key: 1,
-              data,
-              headings: {
-                default: 'Default',
-                description: 'Description',
-                name: 'Name',
-                type: 'Type'
-              },
-              keys: [ 'name', 'type', 'default', 'description' ]
-            })
-        ]
-      )
+  return h(
+    'details', {},
+    [
+      h('summary', { key: 0 }, 'Props'),
+      h(
+        SimpleTable, {
+          key: 1,
+          data,
+          headings: {
+            default: 'Default',
+            description: 'Description',
+            name: 'Name',
+            type: 'Type'
+          },
+          keys: [ 'name', 'type', 'default', 'description' ]
+        })
+    ]
   );
 };

--- a/lib/docs-components/src/common.ts
+++ b/lib/docs-components/src/common.ts
@@ -1,1 +1,0 @@
-export const inStorybook = !(!!process.env['PENULTIMATE']);

--- a/lib/docs-components/src/index.ts
+++ b/lib/docs-components/src/index.ts
@@ -1,10 +1,9 @@
 import { ComponentProps, ComponentType, FC, Fragment, ReactElement, createElement as h } from 'react';
 import { id } from '@not-govuk/component-helpers';
 import { ReactPreview } from './ReactPreview';
-import { inStorybook } from './common';
 import { useDocs } from './context';
 
-import {
+import type {
   Meta as _Meta,
   Preview as _Preview,
   Story as _Story
@@ -20,11 +19,7 @@ export const Meta: FC<MetaProps> = (props) => {
   ctx.title = title;
   ctx.decorators = decorators;
 
-  return (
-    inStorybook
-      ? h(_Meta, props)
-      : null
-  );
+  return null;
 };
 
 export type PreviewProps = ComponentProps<typeof _Preview> & {
@@ -53,18 +48,14 @@ const DocsPreview: FC<PreviewProps> = ({ children, id: _id }) => {
 };
 
 export const Preview: FC<PreviewProps> = (props) => (
-  inStorybook
-    ? h(_Preview, props)
-    : h(DocsPreview, props)
+  h(DocsPreview, props)
 );
 
 export type StoryProps = ComponentProps<typeof _Story> & {
 };
 
-export const Story: FC<StoryProps> = ({ children, ...props }) => (
-  inStorybook
-    ? h(_Story, props)
-    : h(Fragment, {}, children)
+export const Story: FC<StoryProps> = ({ children }) => (
+  h(Fragment, {}, children)
 );
 
 export * from './DocsPage';

--- a/lib/plop-pack/skel/component/package.json.hbs
+++ b/lib/plop-pack/skel/component/package.json.hbs
@@ -28,7 +28,16 @@
   },
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.4.0",
+    "@storybook/addon-docs": "^6.4.0",
     "react": "^16.9.55"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@mdx-js/react": "1.6.22",

--- a/lib/plop-pack/skel/component/spec/Component.stories.mdx.hbs
+++ b/lib/plop-pack/skel/component/spec/Component.stories.mdx.hbs
@@ -1,4 +1,4 @@
-import { Meta, Preview, Props, Story } from '@not-govuk/docs-components';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
 import { {{{properCase name}}} } from '../src/{{{properCase name}}}';
 import readMe from '../README.md';
 

--- a/lib/storybook-preset/index.js
+++ b/lib/storybook-preset/index.js
@@ -55,6 +55,7 @@ const webpack = (webpackConfig = {}, options) => {
       client: options.entry,
       server: 'PLACEHOLDER'
     },
+    storybook: true,
     clean: false
   }).filter(e => e.target !== 'node')[0];
 

--- a/lib/webpack-config/index.js
+++ b/lib/webpack-config/index.js
@@ -29,6 +29,7 @@ const defaultOptions = {
   outDir: './dist',
   production: process.env.NODE_ENV !== 'development',
   server: false,
+  storybook: false,
   tsConfig: 'tsconfig.json'
 };
 
@@ -62,6 +63,7 @@ const generateConfig = (options) => {
   const emitFile = !serverMode;
   const jsDir = serverMode ? '' : 'js/';
   const docs = options.docs;
+  const storybook = options.storybook;
   const clean = (
     options.clean === undefined
       ? !devMode
@@ -331,6 +333,7 @@ const generateConfig = (options) => {
         'process.env.PENULTIMATE': JSON.stringify(true),
         'process.env.WEBPACK': JSON.stringify(true)
       }),
+      !storybook && new webpack.NormalModuleReplacementPlugin(/^@storybook\/addon-docs$/, '@not-govuk\/docs-components'),
       !serverMode && new MiniCssExtractPlugin({
         filename: hashInName ? 'css/[name].[contenthash:8].css': 'css/[name].css',
         chunkFilename: hashInName ? 'css/[name].[contenthash:8].chunk.css' : 'css/[name].chunk.css'


### PR DESCRIPTION
Imports the blocks straight from Storybook and uses webpack's module replacement functionality to do a swap when we aren't running in Storybook.

**Note:** This is a breaking change.