### PR TITLE
webpack-config: Replace file-loader

### DIFF
--- a/components/header/src/CrownLogo.tsx
+++ b/components/header/src/CrownLogo.tsx
@@ -2,7 +2,7 @@ import { FC, createElement as h } from 'react';
 import { LogoProps } from './LogoProps';
 
 const crown = {
-  png: require('govuk-frontend/govuk/assets/images/govuk-logotype-crown.png').default
+  png: require('govuk-frontend/govuk/assets/images/govuk-logotype-crown.png')
 };
 
 const fallbackSrcProps = { src: crown.png }

--- a/components/page/src/GovUKPage.tsx
+++ b/components/page/src/GovUKPage.tsx
@@ -4,13 +4,13 @@ import { Page, PageProps } from './Page';
 
 import '../assets/GovUKPage.scss';
 
-const favicon = require('govuk-frontend/govuk/assets/images/favicon.ico').default;
-const maskIcon = require('govuk-frontend/govuk/assets/images/govuk-mask-icon.svg').default;
-const appleTouchIcon180 = require('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-180x180.png').default;
-const appleTouchIcon167 = require('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-167x167.png').default;
-const appleTouchIcon152 = require('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-152x152.png').default;
-const appleTouchIcon = require('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon.png').default;
-const ogImage = require('govuk-frontend/govuk/assets/images/govuk-opengraph-image.png').default;
+const favicon = require('govuk-frontend/govuk/assets/images/favicon.ico');
+const maskIcon = require('govuk-frontend/govuk/assets/images/govuk-mask-icon.svg');
+const appleTouchIcon180 = require('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-180x180.png');
+const appleTouchIcon167 = require('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-167x167.png');
+const appleTouchIcon152 = require('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon-152x152.png');
+const appleTouchIcon = require('govuk-frontend/govuk/assets/images/govuk-apple-touch-icon.png');
+const ogImage = require('govuk-frontend/govuk/assets/images/govuk-opengraph-image.png');
 
 export type GovUKPageProps = Omit<PageProps, 'govUK'>;
 

--- a/components/page/src/NotGovUKPage.tsx
+++ b/components/page/src/NotGovUKPage.tsx
@@ -4,12 +4,12 @@ import { Page, PageProps } from './Page';
 
 import '../assets/NotGovUKPage.scss';
 
-const favicon = require('../assets/coat-favicon.ico').default;
-const appleTouchIcon180 = require('../assets/coat-apple-touch-icon-180x180.png').default;
-const appleTouchIcon167 = require('../assets/coat-apple-touch-icon-167x167.png').default;
-const appleTouchIcon152 = require('../assets/coat-apple-touch-icon-152x152.png').default;
-const appleTouchIcon = require('../assets/coat-apple-touch-icon.png').default;
-const ogImage = require('../assets/coat-opengraph-image.png').default;
+const favicon = require('../assets/coat-favicon.ico');
+const appleTouchIcon180 = require('../assets/coat-apple-touch-icon-180x180.png');
+const appleTouchIcon167 = require('../assets/coat-apple-touch-icon-167x167.png');
+const appleTouchIcon152 = require('../assets/coat-apple-touch-icon-152x152.png');
+const appleTouchIcon = require('../assets/coat-apple-touch-icon.png');
+const ogImage = require('../assets/coat-opengraph-image.png');
 
 export type NotGovUKPageProps = Omit<PageProps, 'govUK'>;
 

--- a/lib/webpack-config/index.js
+++ b/lib/webpack-config/index.js
@@ -18,7 +18,6 @@ const babelPluginExportNS = require.resolve('@babel/plugin-proposal-export-names
 const babelPluginClassProperties = require.resolve('@babel/plugin-proposal-class-properties');
 const babelPluginPrivateMethods = require.resolve('@babel/plugin-proposal-private-methods');
 const cssLoader = require.resolve('css-loader');
-const fileLoader = require.resolve('file-loader');
 const htmlLoader = require.resolve('html-loader');
 const ignoreLoader = require.resolve('ignore-loader');
 const nodeLoader = require.resolve('node-loader');
@@ -183,6 +182,7 @@ const generateConfig = (options) => {
           : jsDir + (hashInName ? '[name].[contenthash:8].bundle.js' : '[name].bundle.js')
       ),
       chunkFilename: jsDir + (hashInName ? '[name].[contenthash:8].chunk.js' : '[name].chunk.js'),
+      assetModuleFilename: hashInName ? 'assets/[name].[contenthash:8][ext]' : 'assets/[name][ext]',
       path: path.resolve(options.baseDir, options.outDir),
       publicPath: '/public/',
       libraryTarget: serverMode ? 'commonjs2' : undefined
@@ -282,39 +282,24 @@ const generateConfig = (options) => {
         },
         {
           test: /\.(ttf|woff2?)$/,
-          use: [
-            {
-              loader: fileLoader,
-              options: {
-                emitFile: emitFile,
-                name: hashInName ? 'fonts/[name].[contenthash:8].[ext]' : 'fonts/[name].[ext]'
-              }
-            }
-          ]
+          type: 'asset/resource',
+          generator: {
+            filename: hashInName ? 'fonts/[name].[contenthash:8][ext]' : 'fonts/[name][ext]'
+          }
         },
         {
           test: /\.(docx?|pdf)$/,
-          use: [
-            {
-              loader: fileLoader,
-              options: {
-                emitFile: emitFile,
-                name: hashInName ? 'files/[name].[contenthash:8].[ext]' : 'files/[name].[ext]'
-              }
-            }
-          ]
+          type: 'asset/resource',
+          generator: {
+            filename: hashInName ? 'files/[name].[contenthash:8][ext]' : 'files/[name][ext]'
+          }
         },
         {
           test: /\.(gif|ico|jpe?g|png|svg)$/,
-          use: [
-            {
-              loader: fileLoader,
-              options: {
-                emitFile: emitFile,
-                name: hashInName ? 'images/[name].[contenthash:8].[ext]' : 'images/[name].[ext]'
-              }
-            }
-          ]
+          type: 'asset/resource',
+          generator: {
+            filename: hashInName ? 'images/[name].[contenthash:8][ext]' : 'images/[name][ext]'
+          }
         }
       ].filter(id)
     },

--- a/lib/webpack-config/package.json
+++ b/lib/webpack-config/package.json
@@ -25,7 +25,6 @@
     "clean-webpack-plugin": "^4.0.0",
     "css-loader": "^4.2.1",
     "esbuild": "^0.14.28",
-    "file-loader": "^6.0.0",
     "fork-ts-checker-webpack-plugin": "^6.5.0",
     "html-loader": "^1.3.2",
     "ignore-loader": "^0.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1658,7 +1658,6 @@ importers:
       clean-webpack-plugin: ^4.0.0
       css-loader: ^4.2.1
       esbuild: ^0.14.28
-      file-loader: ^6.0.0
       fork-ts-checker-webpack-plugin: ^6.5.0
       html-loader: ^1.3.2
       ignore-loader: ^0.1.2
@@ -1679,25 +1678,24 @@ importers:
       '@babel/preset-env': 7.10.4_@babel+core@7.10.5
       '@babel/preset-react': 7.10.4_@babel+core@7.10.5
       '@babel/preset-typescript': 7.10.4_@babel+core@7.10.5
-      '@mdx-js/loader': 1.6.11_react@16.14.0
-      '@storybook/react-docgen-typescript-plugin': 1.0.1_typescript@4.6.3+webpack@5.70.0
+      '@mdx-js/loader': 1.6.11
+      '@storybook/react-docgen-typescript-plugin': 1.0.1
       '@swc/core': 1.2.163
-      babel-loader: 8.2.1_ce8fda44e7b3087603ce9eb92a110a0a
-      clean-webpack-plugin: 4.0.0_webpack@5.70.0
-      css-loader: 4.3.0_webpack@5.70.0
+      babel-loader: 8.2.1_@babel+core@7.10.5
+      clean-webpack-plugin: 4.0.0
+      css-loader: 4.3.0
       esbuild: 0.14.31
-      file-loader: 6.0.0_webpack@5.70.0
-      fork-ts-checker-webpack-plugin: 6.5.0_typescript@4.6.3+webpack@5.70.0
-      html-loader: 1.3.2_webpack@5.70.0
+      fork-ts-checker-webpack-plugin: 6.5.0
+      html-loader: 1.3.2
       ignore-loader: 0.1.2
-      mini-css-extract-plugin: 1.6.2_webpack@5.70.0
-      node-loader: 2.0.0_webpack@5.70.0
+      mini-css-extract-plugin: 1.6.2
+      node-loader: 2.0.0
       resolve-url-loader: 5.0.0
       sass: 1.32.13
-      sass-loader: 9.0.3_sass@1.32.13+webpack@5.70.0
-      source-map-loader: 3.0.1_webpack@5.70.0
+      sass-loader: 9.0.3_sass@1.32.13
+      source-map-loader: 3.0.1
       webpack-bundle-analyzer: 4.5.0
-      webpack-manifest-plugin: 5.0.0_webpack@5.70.0
+      webpack-manifest-plugin: 5.0.0
       webpack-node-externals: 2.5.1
 
   packages/components:
@@ -4806,11 +4804,11 @@ packages:
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
     dev: true
 
-  /@mdx-js/loader/1.6.11_react@16.14.0:
+  /@mdx-js/loader/1.6.11:
     resolution: {integrity: sha512-yTauPE6EEoUnZ27U5ZklPhygilcAmrHlWWyUm9TShtObGYKzdedPSB9yFdGa6/0UzPdDSZLywcR83paIJvnXAg==}
     dependencies:
       '@mdx-js/mdx': 1.6.11
-      '@mdx-js/react': 1.6.11_react@16.14.0
+      '@mdx-js/react': 1.6.11
       loader-utils: 2.0.0
     transitivePeerDependencies:
       - react
@@ -4880,12 +4878,10 @@ packages:
       - supports-color
     dev: true
 
-  /@mdx-js/react/1.6.11_react@16.14.0:
+  /@mdx-js/react/1.6.11:
     resolution: {integrity: sha512-59qKdVmpxhGcQ7dJKQucKQHxXoS5A1U8x5IYJCitdGVwM6mXkCj1GYyb873oH4cRlxL8BhVHmGalkXTtLqV9Ag==}
     peerDependencies:
       react: ^16.13.1
-    dependencies:
-      react: 16.14.0
     dev: false
 
   /@mdx-js/react/1.6.22_react@16.14.0:
@@ -6255,7 +6251,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/react-docgen-typescript-plugin/1.0.1_typescript@4.6.3+webpack@5.70.0:
+  /@storybook/react-docgen-typescript-plugin/1.0.1:
     resolution: {integrity: sha512-dqbHa+5gaxaklFCuV1WTvljVPTo3QIJgpW4Ln+QeME7osPZUnUhjN2/djvo+sxrWUrTTuqX5jkn291aDngu9Tw==}
     peerDependencies:
       typescript: '>= 3.x'
@@ -6266,10 +6262,8 @@ packages:
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
       micromatch: 4.0.4
-      react-docgen-typescript: 2.2.2_typescript@4.6.3
+      react-docgen-typescript: 2.2.2
       tslib: 2.3.1
-      typescript: 4.6.3
-      webpack: 5.70.0_webpack-cli@4.9.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8207,7 +8201,7 @@ packages:
       - supports-color
     dev: true
 
-  /babel-loader/8.2.1_ce8fda44e7b3087603ce9eb92a110a0a:
+  /babel-loader/8.2.1_@babel+core@7.10.5:
     resolution: {integrity: sha512-dMF8sb2KQ8kJl21GUjkW1HWmcsL39GOV5vnzjqrCzEPNY0S0UfMLnumidiwIajDSBmKhYf5iRW+HXaM4cvCKBw==}
     engines: {node: '>= 8.9'}
     peerDependencies:
@@ -8220,7 +8214,6 @@ packages:
       make-dir: 2.1.0
       pify: 4.0.1
       schema-utils: 2.7.1
-      webpack: 5.70.0_webpack-cli@4.9.2
     dev: false
 
   /babel-loader/8.2.3_e48b7ef51183a80246fa903efd6aff5e:
@@ -9256,14 +9249,13 @@ packages:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
 
-  /clean-webpack-plugin/4.0.0_webpack@5.70.0:
+  /clean-webpack-plugin/4.0.0:
     resolution: {integrity: sha512-WuWE1nyTNAyW5T7oNyys2EN0cfP2fdRxhxnIQWiAp0bMabPdHhoGxM8A6YL2GhqwgrPnnaemVE7nv5XJ2Fhh2w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       webpack: '>=4.0.0 <6.0.0'
     dependencies:
       del: 4.1.1
-      webpack: 5.70.0_webpack-cli@4.9.2
     dev: false
 
   /cli-boxes/2.2.1:
@@ -9827,7 +9819,7 @@ packages:
       webpack: 4.43.0
     dev: true
 
-  /css-loader/4.3.0_webpack@5.70.0:
+  /css-loader/4.3.0:
     resolution: {integrity: sha512-rdezjCjScIrsL8BSYszgT4s476IcNKt6yX69t0pHjJVnPUTDpn4WfIpDQTN3wCJvUvfsz/mFjuGOekf3PY3NUg==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -9845,7 +9837,6 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 2.7.1
       semver: 7.3.5
-      webpack: 5.70.0_webpack-cli@4.9.2
     dev: false
 
   /css-loader/5.2.7_webpack@5.70.0:
@@ -11582,17 +11573,6 @@ packages:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  /file-loader/6.0.0_webpack@5.70.0:
-    resolution: {integrity: sha512-/aMOAYEFXDdjG0wytpTL5YQLfZnnTmLNjn+AIrJ/6HVnTfDqLsVKUUwkDf4I4kgex36BvjuXEn/TX9B/1ESyqQ==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
-    dependencies:
-      loader-utils: 2.0.0
-      schema-utils: 2.7.0
-      webpack: 5.70.0_webpack-cli@4.9.2
-    dev: false
-
   /file-loader/6.2.0_webpack@4.43.0:
     resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}
     engines: {node: '>= 10.13.0'}
@@ -11854,6 +11834,35 @@ packages:
       worker-rpc: 0.1.1
     dev: true
 
+  /fork-ts-checker-webpack-plugin/6.5.0:
+    resolution: {integrity: sha512-cS178Y+xxtIjEUorcHddKS7yCMlrDPV31mt47blKKRfMd70Kxu5xruAFE2o9sDY6wVC5deuob/u/alD04YYHnw==}
+    engines: {node: '>=10', yarn: '>=1.0.0'}
+    peerDependencies:
+      eslint: '>= 6'
+      typescript: '>= 2.7'
+      vue-template-compiler: '*'
+      webpack: '>= 4'
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+      vue-template-compiler:
+        optional: true
+    dependencies:
+      '@babel/code-frame': 7.16.7
+      '@types/json-schema': 7.0.10
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      cosmiconfig: 6.0.0
+      deepmerge: 4.2.2
+      fs-extra: 9.1.0
+      glob: 7.2.0
+      memfs: 3.2.0
+      minimatch: 3.1.2
+      schema-utils: 2.7.0
+      semver: 7.3.5
+      tapable: 1.1.3
+    dev: false
+
   /fork-ts-checker-webpack-plugin/6.5.0_typescript@4.6.3+webpack@4.43.0:
     resolution: {integrity: sha512-cS178Y+xxtIjEUorcHddKS7yCMlrDPV31mt47blKKRfMd70Kxu5xruAFE2o9sDY6wVC5deuob/u/alD04YYHnw==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
@@ -11914,6 +11923,7 @@ packages:
       tapable: 1.1.3
       typescript: 4.6.3
       webpack: 5.70.0_webpack-cli@4.9.2
+    dev: true
 
   /form-data/2.3.3:
     resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
@@ -12770,7 +12780,7 @@ packages:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
 
-  /html-loader/1.3.2_webpack@5.70.0:
+  /html-loader/1.3.2:
     resolution: {integrity: sha512-DEkUwSd0sijK5PF3kRWspYi56XP7bTNkyg5YWSzBdjaSDmvCufep5c4Vpb3PBf6lUL0YPtLwBfy9fL0t5hBAGA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -12780,7 +12790,6 @@ packages:
       htmlparser2: 4.1.0
       loader-utils: 2.0.0
       schema-utils: 3.0.0
-      webpack: 5.70.0_webpack-cli@4.9.2
     dev: false
 
   /html-minifier-terser/5.1.1:
@@ -15229,7 +15238,7 @@ packages:
       tiny-warning: 1.0.3
     dev: true
 
-  /mini-css-extract-plugin/1.6.2_webpack@5.70.0:
+  /mini-css-extract-plugin/1.6.2:
     resolution: {integrity: sha512-WhDvO3SjGm40oV5y26GjMJYjd2UMqrLAGKy5YS2/3QKJy2F7jgynuHTir/tgUUOiNQu5saXHdc8reo7YuhhT4Q==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -15237,7 +15246,6 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.70.0_webpack-cli@4.9.2
       webpack-sources: 1.4.3
     dev: false
 
@@ -15552,14 +15560,13 @@ packages:
       vm-browserify: 1.1.2
     dev: true
 
-  /node-loader/2.0.0_webpack@5.70.0:
+  /node-loader/2.0.0:
     resolution: {integrity: sha512-I5VN34NO4/5UYJaUBtkrODPWxbobrE4hgDqPrjB25yPkonFhCmZ146vTH+Zg417E9Iwoh1l/MbRs1apc5J295Q==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
       loader-utils: 2.0.2
-      webpack: 5.70.0_webpack-cli@4.9.2
     dev: false
 
   /node-plop/0.26.2:
@@ -16965,12 +16972,19 @@ packages:
       react-dom: 16.14.0_react@16.14.0
     dev: true
 
+  /react-docgen-typescript/2.2.2:
+    resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+    dev: false
+
   /react-docgen-typescript/2.2.2_typescript@4.6.3:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
       typescript: 4.6.3
+    dev: true
 
   /react-docgen/5.4.0:
     resolution: {integrity: sha512-JBjVQ9cahmNlfjMGxWUxJg919xBBKAoy3hgDgKERbR+BcF4ANpDuzWAScC7j27hZfd8sJNmMPOLWo9+vB/XJEQ==}
@@ -17870,7 +17884,7 @@ packages:
       walker: 1.0.7
     dev: true
 
-  /sass-loader/9.0.3_sass@1.32.13+webpack@5.70.0:
+  /sass-loader/9.0.3_sass@1.32.13:
     resolution: {integrity: sha512-fOwsP98ac1VMme+V3+o0HaaMHp8Q/C9P+MUazLFVi3Jl7ORGHQXL1XeRZt3zLSGZQQPC8xE42Y2WptItvGjDQg==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -17892,7 +17906,6 @@ packages:
       sass: 1.32.13
       schema-utils: 2.7.1
       semver: 7.3.5
-      webpack: 5.70.0_webpack-cli@4.9.2
     dev: false
 
   /sass/1.32.13:
@@ -18381,7 +18394,7 @@ packages:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
 
-  /source-map-loader/3.0.1_webpack@5.70.0:
+  /source-map-loader/3.0.1:
     resolution: {integrity: sha512-Vp1UsfyPvgujKQzi4pyDiTOnE3E4H+yHvkVRN3c/9PJmQS4CQJExvcDvaX/D+RV+xQben9HJ56jMJS3CgUeWyA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -18390,7 +18403,6 @@ packages:
       abab: 2.0.6
       iconv-lite: 0.6.3
       source-map-js: 1.0.2
-      webpack: 5.70.0_webpack-cli@4.9.2
     dev: false
 
   /source-map-resolve/0.5.3:
@@ -20131,14 +20143,13 @@ packages:
       uuid: 3.4.0
     dev: true
 
-  /webpack-manifest-plugin/5.0.0_webpack@5.70.0:
+  /webpack-manifest-plugin/5.0.0:
     resolution: {integrity: sha512-8RQfMAdc5Uw3QbCQ/CBV/AXqOR8mt03B6GJmRbhWopE8GzRfEpn+k0ZuWywxW+5QZsffhmFDY1J6ohqJo+eMuw==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       webpack: ^5.47.0
     dependencies:
       tapable: 2.2.1
-      webpack: 5.70.0_webpack-cli@4.9.2
       webpack-sources: 2.3.1
     dev: false
 


### PR DESCRIPTION
Replaces `file-loader` with webpack v5's asset modules.

**BREAKING:** When `require()`ing in assets, one should no longer use the `.default` property. (Just use the object itself.)