### PR TITLE
Enhance express-adapter and re-use

### DIFF
--- a/lib/asset-proxy/package.json
+++ b/lib/asset-proxy/package.json
@@ -19,8 +19,8 @@
   "author": "Daniel A.C. Martin <npm@daniel-martin.co.uk> (http://daniel-martin.co.uk/)",
   "license": "MIT",
   "dependencies": {
+    "@not-govuk/express-adapter": "workspace:^0.4.2",
     "@not-govuk/restify": "workspace:^0.4.0",
-    "etag": "^1.8.1",
     "http-proxy-middleware": "^2.0.0"
   },
   "peerDependencies": {
@@ -29,8 +29,6 @@
     "webpack-hot-middleware": "^2.25.0"
   },
   "devDependencies": {
-    "@types/connect": "3.4.35",
-    "@types/express-serve-static-core": "4.17.28",
     "@types/webpack": "5.28.0",
     "@types/webpack-dev-middleware": "5.0.2",
     "@types/webpack-hot-middleware": "2.25.6",

--- a/lib/asset-proxy/src/index.ts
+++ b/lib/asset-proxy/src/index.ts
@@ -43,7 +43,7 @@ export const assetProxy = ({
   // Serve assets built by webpack
   httpd.pre(webpack.serveFiles);
   // Endpoint for HMR websocket
-  httpd.get(webpack.hotPath, webpack.hot);
+  httpd.get(webpack.hotPath, webpack.hotMiddleware);
   // Proxy everything else
   httpd.get('/*', proxyMiddleware);
   httpd.post('/*', proxyMiddleware);

--- a/lib/express-adapter/package.json
+++ b/lib/express-adapter/package.json
@@ -29,5 +29,8 @@
     "jest-environment-jsdom": "28.1.0",
     "ts-jest": "28.0.2",
     "typescript": "4.6.4"
+  },
+  "dependencies": {
+    "etag": "^1.8.1"
   }
 }

--- a/lib/express-adapter/src/index.ts
+++ b/lib/express-adapter/src/index.ts
@@ -1,29 +1,46 @@
-import type { Middleware as RestifyMiddleware } from '@not-govuk/restify';
+import etag from 'etag';
+
 import type { NextHandleFunction as ExpressMiddleware } from 'connect';
 import type { Response } from 'express-serve-static-core';
+import type { Middleware as RestifyMiddleware } from '@not-govuk/restify';
 
 export const adapt = (middleware: ExpressMiddleware): RestifyMiddleware => (req, res, next) => {
-  const res2: unknown = {
-    ...res,
-    getHeader(key) {
-      res.getHeader(key);
-    },
-    setHeader(key, val) {
-      res.setHeader(key, val);
-    },
-    send(content) {
-      res.send(content);
-      next();
-    },
-    end() {
-      res.statusCode = this.statusCode;
-      res.end();
-      next(false);
-    },
-    redirect(uri: string) { return res.redirect(uri, next) }
-  };
+  const expressRes: unknown = new Proxy(res, {
+    get(target, prop, receiver) {
+      switch (prop) {
+        case 'end':
+          return () => {
+            target.end();
+            return next(false);
+          }
+        case 'redirect':
+          return (uri: string) => {
+            return target.redirect(uri, next)
+          }
+        case 'send':
+          return (content) => {
+            target.statusCode = target.statusCode || 200;
 
-  return middleware(req, res2 as Response, next);
+            target.setHeader('Cache-Control', 'private, no-cache');
+
+            if (typeof content === 'string' || content instanceof Buffer) {
+              target.setHeader('ETag', etag(content, { weak: true }));
+              target.sendRaw(content);
+            } else {
+              target.send(content);
+            }
+
+            return next(false);
+          }
+      }
+
+      return Reflect.get(target, prop, receiver);
+    }
+  });
+
+  expressRes['locals'] = expressRes['locals'] || {};
+
+  return middleware(req, expressRes as Response, next);
 };
 
 export default adapt;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1453,22 +1453,18 @@ importers:
 
   lib/asset-proxy:
     specifiers:
+      '@not-govuk/express-adapter': workspace:^0.4.2
       '@not-govuk/restify': workspace:^0.4.0
-      '@types/connect': 3.4.35
-      '@types/express-serve-static-core': 4.17.28
       '@types/webpack': 5.28.0
       '@types/webpack-dev-middleware': 5.0.2
       '@types/webpack-hot-middleware': 2.25.6
-      etag: ^1.8.1
       http-proxy-middleware: ^2.0.0
       typescript: 4.6.4
     dependencies:
+      '@not-govuk/express-adapter': link:../express-adapter
       '@not-govuk/restify': link:../restify
-      etag: 1.8.1
       http-proxy-middleware: 2.0.4
     devDependencies:
-      '@types/connect': 3.4.35
-      '@types/express-serve-static-core': 4.17.28
       '@types/webpack': 5.28.0_webpack-cli@4.9.2
       '@types/webpack-dev-middleware': 5.0.2_webpack-cli@4.9.2
       '@types/webpack-hot-middleware': 2.25.6_webpack-cli@4.9.2
@@ -1586,10 +1582,13 @@ importers:
       '@not-govuk/restify': workspace:^0.4.2
       '@types/connect': 3.4.35
       '@types/express-serve-static-core': 4.17.28
+      etag: ^1.8.1
       jest: 28.1.0
       jest-environment-jsdom: 28.1.0
       ts-jest: 28.0.2
       typescript: 4.6.4
+    dependencies:
+      etag: 1.8.1
     devDependencies:
       '@not-govuk/restify': link:../restify
       '@types/connect': 3.4.35
@@ -12090,7 +12089,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dev: true
 
   /follow-redirects/1.14.9_debug@4.3.2:
     resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}
@@ -12102,6 +12100,7 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.2
+    dev: true
 
   /for-in/1.0.2:
     resolution: {integrity: sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=}
@@ -13232,7 +13231,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.5
-      follow-redirects: 1.14.9_debug@4.3.2
+      follow-redirects: 1.14.9
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
Enhances the 'express-adapter' package so that it can also be used by the asset-proxy when consuming the webpack middleware.