### PR TITLE
Add underlying support for cookies with consent

### DIFF
--- a/apps/govuk-docs/package.json
+++ b/apps/govuk-docs/package.json
@@ -6,10 +6,11 @@
   "main": "dist/server/index.js",
   "scripts": {
     "start": "node .",
+    "start:test": "COOKIES_SECURE=no node .",
     "test": "npm run test:unit",
     "test:ci": "npm test && npm run test:functional:ci",
     "test:functional": "cypress run ${CYPRESS_PROJECT_ID:+--record ${CYPRESS_FLAGS}}",
-    "test:functional:ci": "start-server-and-test start 'http-get://localhost:8080/readiness' test:functional",
+    "test:functional:ci": "start-server-and-test 'start:test' 'http-get://localhost:8080/readiness' test:functional",
     "test:unit": "jest --passWithNoTests",
     "build": "webpack",
     "package:aws-lambda": "sls package -c aws.serverless.yml -p pkg/aws-lambda",

--- a/apps/govuk-docs/src/server/config.ts
+++ b/apps/govuk-docs/src/server/config.ts
@@ -3,6 +3,7 @@ import commonConfig from '../common/config';
 
 const serverConfig = {
   ...commonConfig,
+  encryptionSecret: process.env.ENCRYPTION_SECRET || 'changeme',
   env: process.env.NODE_ENV as NodeEnv,
   logger: {
     destination: process.env.LOG_DESTINATION,

--- a/apps/govuk-docs/src/server/config.ts
+++ b/apps/govuk-docs/src/server/config.ts
@@ -1,9 +1,15 @@
-import { Mode, NodeEnv } from '@not-govuk/engine';
+import { Mode, NodeEnv, defaultsTrue, defaultsFalse } from '@not-govuk/engine';
 import commonConfig from '../common/config';
+
+const env = process.env.NODE_ENV as NodeEnv;
+const devMode = env === NodeEnv.Development;
 
 const serverConfig = {
   ...commonConfig,
-  encryptionSecret: process.env.ENCRYPTION_SECRET || 'changeme',
+  cookies: {
+    secret: process.env.COOKIES_SECRET || 'changeme',
+    secure: ( devMode ? defaultsFalse : defaultsTrue )(process.env.COOKIES_SECURE)
+  },
   env: process.env.NODE_ENV as NodeEnv,
   logger: {
     destination: process.env.LOG_DESTINATION,

--- a/apps/govuk-docs/src/server/httpd.ts
+++ b/apps/govuk-docs/src/server/httpd.ts
@@ -22,6 +22,7 @@ export const createServer = ({ entrypoints, port }: httpdOptions) => {
       publicPath: '/public/',
       entrypoints
     },
+    encryptionSecret: config.encryptionSecret,
     env: config.env,
     httpd: {
       host: config.httpd.host,

--- a/apps/govuk-docs/src/server/httpd.ts
+++ b/apps/govuk-docs/src/server/httpd.ts
@@ -22,7 +22,10 @@ export const createServer = ({ entrypoints, port }: httpdOptions) => {
       publicPath: '/public/',
       entrypoints
     },
-    encryptionSecret: config.encryptionSecret,
+    cookies: {
+      secret: config.cookies.secret,
+      secure: config.cookies.secure
+    },
     env: config.env,
     httpd: {
       host: config.httpd.host,

--- a/apps/govuk-template/package.json
+++ b/apps/govuk-template/package.json
@@ -6,10 +6,11 @@
   "main": "dist/server/index.js",
   "scripts": {
     "start": "node .",
+    "start:test": "COOKIES_SECURE=no node .",
     "test": "npm run test:unit",
     "test:ci": "npm test && npm run test:functional:ci",
     "test:functional": "cypress run ${CYPRESS_PROJECT_ID:+--record ${CYPRESS_FLAGS}}",
-    "test:functional:ci": "start-server-and-test start 'http-get://localhost:8080/readiness' test:functional",
+    "test:functional:ci": "start-server-and-test 'start:test' 'http-get://localhost:8080/readiness' test:functional",
     "test:unit": "jest --passWithNoTests",
     "build": "webpack",
     "package:aws-lambda": "sls package -c aws.serverless.yml -p pkg/aws-lambda",

--- a/apps/govuk-template/src/server/config.ts
+++ b/apps/govuk-template/src/server/config.ts
@@ -1,4 +1,4 @@
-import { AuthMethod, Mode, NodeEnv } from '@not-govuk/engine';
+import { AuthMethod, Mode, NodeEnv, defaultsFalse, defaultsTrue } from '@not-govuk/engine';
 import commonConfig from '../common/config';
 
 const env = process.env.NODE_ENV as NodeEnv;
@@ -31,7 +31,10 @@ const serverConfig = {
       redirectUri: process.env.OIDC_REDIRECT_URI || 'http://localhost:8080'
     }
   },
-  encryptionSecret: process.env.ENCRYPTION_SECRET || 'changeme',
+  cookies: {
+    secret: process.env.COOKIES_SECRET || 'changeme',
+    secure: ( devMode ? defaultsFalse : defaultsTrue )(process.env.COOKIES_SECURE)
+  },
   env,
   logger: {
     destination: process.env.LOG_DESTINATION,
@@ -42,8 +45,8 @@ const serverConfig = {
     port: Number(process.env.PORT) || Number(process.env.LISTEN_PORT) || 8080
   },
   mode: (process.env.MODE || 'server') as Mode,
-  privacy: !!(process.env.PRIVACY && process.env.PRIVACY.match(/(yes|true)/i)),
-  ssrOnly: !!(process.env.SSR_ONLY && process.env.SSR_ONLY.match(/(yes|true)/i))
+  privacy: defaultsFalse(process.env.PRIVACY),
+  ssrOnly: defaultsFalse(process.env.SSR_ONLY)
 };
 
 export default serverConfig;

--- a/apps/govuk-template/src/server/config.ts
+++ b/apps/govuk-template/src/server/config.ts
@@ -9,7 +9,6 @@ const serverConfig = {
   ...commonConfig,
   auth: {
     method: process.env.AUTH_METHOD || ( devMode ? AuthMethod.Dummy : AuthMethod.Basic ),
-    sessionsSecret: process.env.SESSIONS_SECRET || 'changeme',
     dummy: {
       username: 'TestUser',
       groups: [],
@@ -32,6 +31,7 @@ const serverConfig = {
       redirectUri: process.env.OIDC_REDIRECT_URI || 'http://localhost:8080'
     }
   },
+  encryptionSecret: process.env.ENCRYPTION_SECRET || 'changeme',
   env,
   logger: {
     destination: process.env.LOG_DESTINATION,

--- a/apps/govuk-template/src/server/httpd.ts
+++ b/apps/govuk-template/src/server/httpd.ts
@@ -27,9 +27,10 @@ export const createServer = ({ entrypoints, port }: httpdOptions) => {
       ( config.auth.method === AuthMethod.None && { method: AuthMethod.None } )
         || ( config.auth.method === AuthMethod.Dummy && { method: AuthMethod.Dummy, ...config.auth.dummy } )
         || ( config.auth.method === AuthMethod.Headers && { method: AuthMethod.Headers, ...config.auth.headers } )
-        || ( config.auth.method === AuthMethod.Basic && { method: AuthMethod.Basic, ...config.auth.basic, sessionsSecret: config.auth.sessionsSecret } )
-        || ( config.auth.method === AuthMethod.OIDC && { method: AuthMethod.OIDC, ...config.auth.oidc, sessionsSecret: config.auth.sessionsSecret } )
+        || ( config.auth.method === AuthMethod.Basic && { method: AuthMethod.Basic, ...config.auth.basic } )
+        || ( config.auth.method === AuthMethod.OIDC && { method: AuthMethod.OIDC, ...config.auth.oidc } )
     ),
+    encryptionSecret: config.encryptionSecret,
     env: config.env,
     graphQL: {
       schema: graphQLSchema

--- a/apps/govuk-template/src/server/httpd.ts
+++ b/apps/govuk-template/src/server/httpd.ts
@@ -30,7 +30,10 @@ export const createServer = ({ entrypoints, port }: httpdOptions) => {
         || ( config.auth.method === AuthMethod.Basic && { method: AuthMethod.Basic, ...config.auth.basic } )
         || ( config.auth.method === AuthMethod.OIDC && { method: AuthMethod.OIDC, ...config.auth.oidc } )
     ),
-    encryptionSecret: config.encryptionSecret,
+    cookies: {
+      secret: config.cookies.secret,
+      secure: config.cookies.secure
+    },
     env: config.env,
     graphQL: {
       schema: graphQLSchema

--- a/lib/consent-cookies/.gitignore
+++ b/lib/consent-cookies/.gitignore
@@ -1,0 +1,5 @@
+dist/
+node_modules/
+package-lock.json
+pnpm-lock.yaml
+tsconfig.tsbuildinfo

--- a/lib/consent-cookies/README.md
+++ b/lib/consent-cookies/README.md
@@ -1,0 +1,178 @@
+NotGovUK - Consent-Cookies
+==========================
+
+Connect middleware to parse and set cookies only with user consent. This
+aids compliance with European regulations.
+
+Also provides a session via a cookie. (Accessible by reading and writing
+to `req.session`.)
+
+Tested on Restify but should work on other Connect-like systems such as
+Express.
+
+Features
+--------
+
+- Essential cookies
+- Optional cookies with opt-in system
+- Sessions
+- Encryption (except when `httpOnly` is set to false)
+- Secure by default
+
+
+Using this package
+------------------
+
+First install the package into your project:
+
+```shell
+npm install -S @not-govuk/consent-cookies
+```
+
+Then use it in your code as follows:
+
+```js
+const restify = require('restify');
+const consentCookies = require('@not-govuk/consent-cookies');
+
+consy myCookies = [
+  {
+    name: 'ga',
+    description: 'Enables us to track you use of the site and helps us to optimise your experience.',
+    group: 'Analytics',
+    httpOnly: false
+  },
+  {
+    name: 'seen,
+    description: 'Allows us to know whether you have visited the site before.',
+    group: 'Analytics'
+  }
+];
+
+const httpd = restify.createServer();
+
+httpd.use(consentCookies({ cookies: myCookies, secret: 'my-encryption-secret' }));
+
+httpd.get('/', (req, res, next) => {
+  const seen = req.cookies['seen'] || false;
+  const message = (
+    seen
+      ? 'Hello!'
+      : 'Welcome back.'
+  );
+
+  res.setCookie('seen', true);
+  res.send(`<html><body>${seen}</body></html>`);
+  next();
+});
+
+httpd.listen(8080, '0.0.0.0', () => {
+  httpd.log.info('%s listening at %s', httpd.name, httpd.url);
+});
+```
+
+Subsequent middlewares will be able to discover the cookies available for
+use via `req.cookiesMeta` as well as the current cookies of enabled
+cookies via `req.cookies`. New cookies can be set with `res.setCookie()`.
+
+
+### `consentCookies(options: object)`
+
+Provides a middleware that can be given to `httpd.use()`.
+
+Options object:
+
+- **`cookies: object`**
+  A description of all the cookies your application uses. Only cookies
+  described here will be available for reading and writing.
+  - **`name: string`**
+    The name of the cookie.
+  - **`description: string`**
+    A description of the cookies purpose. (To be shown to the user.)
+  - **`group?: string`**
+    The category that an optional cookie belongs to. e.g. 'Analytics'. If
+    the cookie is mandatory, do not define this and the cookie will
+    always be available.
+  - **`httpOnly?: boolean = true`**
+    Whether the cookie can be accessed on the client. Unlike other cookie
+    options, this _must_ be defined here and cannot be provided later,
+    when setting the cookie. This is because consent-cookies will encrypt
+    all httpOnly cookies as a security precaution and so needs to know
+    whether to decrypt them when reading them.
+  - **Other `cookie.serialize()` options besides `encode`**
+    See: https://www.npmjs.com/package/cookie
+- **`secret: string`**
+  A secret that is used to encrypt your cookies. You should ensure that
+  you set this in production to ensure that they cannot be decrypted by
+  an attacker. If you horizontally scale your application, you must
+  ensure that the secret is shared between each instance, so that they
+  can decrypt cookies that were set by other instances.
+- **`provideSession?: boolean = true`**
+  Whether to provide a session at `req.session`. Set this to `false` if
+  you do not require a session or if you wish to provide a session using
+  a different middleware.
+- **`cookie.serialize()` options besides `encode` and `httpOnly`**
+  These will become the defaults within your application. Note that we
+  set some sensible defaults for your with a 'secure by default' mindset,
+  so you should only need to provide these options in order to loosen up
+  the security.
+  See: https://www.npmjs.com/package/cookie
+
+
+### `res.setCookie(name: string, value: any[, options: object])`
+
+Sets a cookie.
+
+- **`name: string`**
+  The name of the cookie you wish to set.
+  **Note:** If this cookie has not been consented to and is not
+  mandatory, an exception will be thrown.
+- **`value: any`**
+  The value you wish to set for the cookie. This can be anything that
+  `JSON.stringify` can serialise but must fit within the size limits of
+  cookies.
+- **`options: object`**
+  Any `cookie.serialize()` option besides `encode` and `httpOnly`.
+  (To set `httpOnly` you must declare it when initially describing the
+  cookie.)
+  See: https://www.npmjs.com/package/cookie
+
+
+### `req.cookies`
+
+An object containing the data from all active cookies.
+
+
+### `req.cookiesMeta`
+
+An object that contains a description of all supported cookies and
+whether the user has consented to them.
+
+
+Working on this package
+-----------------------
+
+Before working on this package you must install its dependencies using
+the following command:
+
+```shell
+pnpm install
+```
+
+
+### Building
+
+Build the package by compiling the source code.
+
+```shell
+npm run build
+```
+
+
+### Clean-up
+
+Remove any previously built files.
+
+```shell
+npm run clean
+```

--- a/lib/consent-cookies/jest.config.js
+++ b/lib/consent-cookies/jest.config.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const baseConfig = require('../../jest.config.base');
+
+const config = {
+  ...baseConfig,
+  collectCoverageFrom: [
+    '<rootDir>/src/**.{ts,tsx}',
+  ],
+  testMatch: [
+    '<rootDir>/spec/**.{ts,tsx}'
+  ]
+};
+
+module.exports = config;

--- a/lib/consent-cookies/package.json
+++ b/lib/consent-cookies/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@not-govuk/consent-cookies",
+  "version": "0.4.2",
+  "description": "Connect middleware to parse and set cookies only with user consent.",
+  "main": "src/index.ts",
+  "publishConfig": {
+    "main": "dist/index.js",
+    "typings": "dist/index.d.ts"
+  },
+  "files": [
+    "/dist"
+  ],
+  "scripts": {
+    "test": "jest",
+    "prepublishOnly": "npm run clean && npm run build",
+    "build": "tsc",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo"
+  },
+  "author": "Daniel A.C. Martin <npm@daniel-martin.co.uk> (http://daniel-martin.co.uk/)",
+  "license": "MIT",
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "devDependencies": {
+    "@types/connect": "^3.4.35",
+    "@types/cookie": "^0.5.1",
+    "@types/cryptr": "^4.0.1",
+    "jest": "28.1.0",
+    "jest-environment-jsdom": "28.1.0",
+    "ts-jest": "28.0.2",
+    "typescript": "4.6.4"
+  },
+  "dependencies": {
+    "cookie": "^0.5.0",
+    "cryptr": "^6.0.3"
+  }
+}

--- a/lib/consent-cookies/src/common.ts
+++ b/lib/consent-cookies/src/common.ts
@@ -1,0 +1,27 @@
+import type { CookieSerializeOptions } from 'cookie';
+import type { IncomingMessage as _Request, ServerResponse as _Response } from 'http';
+import type { NextFunction } from 'connect';
+
+export type CookieOptions = Omit<CookieSerializeOptions, 'encode'>;
+
+export type SetCookie = (name: string, value: any, options: Omit<CookieOptions, 'httpOnly'>) => void;
+export type SetCookieConsent = (value: string[]) => void;
+
+type Request = _Request & {
+  cookies?: object
+  cookiesMeta?: object
+  session?: object
+};
+
+type Response = _Response & {
+  setCookie?: SetCookie
+  setCookieConsent?: SetCookieConsent
+};
+
+export type Middleware = (req: Request, res: Response, next: NextFunction) => void;
+
+export type Cookie = CookieOptions & {
+  name: string
+  description: string
+  group?: string
+};

--- a/lib/consent-cookies/src/index.ts
+++ b/lib/consent-cookies/src/index.ts
@@ -12,7 +12,9 @@ export type ConsentCookiesOptions = CookieOptions & {
 
 const consentCookie: Cookie = {
   name: 'consent',
-  description: 'A store of the cookies that you have consented to.'
+  description: 'A store of the cookies that you have consented to.',
+  httpOnly: false,
+  sameSite: 'lax'
 };
 
 const id = <T>(v: T): T => v;
@@ -109,10 +111,7 @@ export const consentCookies = ({
     };
 
     const setCookieConsent: SetCookieConsent = function(value: string[]) {
-      this.setCookie(consentCookie.name, value, {
-        httpOnly: false,
-        sameSite: 'lax'
-      });
+      this.setCookie(consentCookie.name, value);
     };
 
     // Provide method for setting cookies

--- a/lib/consent-cookies/src/index.ts
+++ b/lib/consent-cookies/src/index.ts
@@ -1,0 +1,130 @@
+import cookie from 'cookie';
+import Cryptr from 'cryptr';
+import { sessions, sessionCookie } from './sessions';
+
+import type { Cookie, CookieOptions, Middleware, SetCookie, SetCookieConsent } from './common';
+
+export type ConsentCookiesOptions = CookieOptions & {
+  cookies: Cookie[]
+  provideSession?: boolean
+  secret: string
+};
+
+const consentCookie: Cookie = {
+  name: 'consent',
+  description: 'A store of the cookies that you have consented to.'
+};
+
+const id = <T>(v: T): T => v;
+
+const encodeClear = (v: any) => JSON.stringify(v);
+const decodeClear = (v: any) => {
+  try {
+    return JSON.parse(v);
+  } catch (e) {
+    return undefined;
+  }
+};
+
+export const consentCookies = ({
+  cookies: _cookies,
+  provideSession = true,
+  secret,
+  ...defaults
+}: ConsentCookiesOptions): Middleware => {
+  const cryptr = new Cryptr(secret);
+  const encodeSecure = (v: any) => cryptr.encrypt(encodeClear(v));
+  const decodeSecure = (v: any) => {
+    try {
+      return decodeClear(cryptr.decrypt(v));
+    } catch (e) {
+      return undefined;
+    }
+  };
+  const cookies = ([
+    consentCookie,
+    provideSession ? sessionCookie : undefined,
+    ..._cookies
+  ]).filter(id);
+
+  return (req, res, next) => {
+    const cookieData = cookie.parse(req.headers.cookie || '');
+    const _consent = cookieData[consentCookie.name]
+    const consent = _consent || [];
+    const active = cookies
+      .filter(e => e.group === undefined || consent.includes(e.name))
+      .reduce(
+        (acc, { name, ...cur }) => ({
+          ...acc,
+          [name]: cur
+        }),
+        {}
+      );
+
+    // Store meta-data for available cookies
+    req.cookiesMeta = cookies.map(({ name, description, group }) => ({
+      name,
+      description,
+      group,
+      consent: consent.includes(name)
+    }));
+
+    // Make data in cookies available on the request
+    req.cookies = Object.keys(cookieData)
+      .filter(e => active[e])
+      .reduce(
+        (acc, cur) => ({
+          ...acc,
+          [cur]: (
+            active[cur].httpOnly === false
+              ? decodeClear(cookieData[cur])
+              : decodeSecure(cookieData[cur])
+          )
+        }),
+        {}
+      );
+
+    const setCookie: SetCookie = function(name, value, options) {
+      if (active[name]) {
+        const httpOnly = active[name].httpOnly !== false; // No access from JavaScript, by default
+        const content = (
+          !httpOnly
+            ? encodeClear(value)
+            : encodeSecure(value)
+        );
+        this.setHeader('Set-Cookie', cookie.serialize(name, content, {
+          path: '/', // Cover entire site
+          domain: undefined, // Do NOT cover subdomains (yes, really)
+          sameSite: 'strict', // Some CSRF protection
+          secure: process.env['NODE_ENV'] === 'production', // Require TLS in production
+          ...defaults,
+          ...options,
+          httpOnly
+        }))
+      } else {
+        throw new Error(`No consent for cookie, "${name}".`);
+      }
+    };
+
+    const setCookieConsent: SetCookieConsent = function(value: string[]) {
+      this.setCookie(consentCookie.name, value, {
+        httpOnly: false,
+        sameSite: 'lax'
+      });
+    };
+
+    // Provide method for setting cookies
+    res.setCookie = setCookie;
+    res.setCookieConsent = setCookieConsent;
+
+    // Set initial consent cookie if required
+    if (_consent === undefined) {
+      res.setCookieConsent([]);
+    }
+
+    provideSession ? sessions(req, res, next) : next();
+  }
+};
+
+export default consentCookies;
+export type { Cookie };

--- a/lib/consent-cookies/src/index.ts
+++ b/lib/consent-cookies/src/index.ts
@@ -86,7 +86,8 @@ export const consentCookies = ({
 
     const setCookie: SetCookie = function(name, value, options) {
       if (active[name]) {
-        const httpOnly = active[name].httpOnly !== false; // No access from JavaScript, by default
+        const { description, group, httpOnly: _httpOnly, ...declaration } = active[name];
+        const httpOnly = _httpOnly !== false; // No access from JavaScript, by default
         const content = (
           !httpOnly
             ? encodeClear(value)
@@ -98,6 +99,7 @@ export const consentCookies = ({
           sameSite: 'strict', // Some CSRF protection
           secure: process.env['NODE_ENV'] === 'production', // Require TLS in production
           ...defaults,
+          ...declaration,
           ...options,
           httpOnly
         }))

--- a/lib/consent-cookies/src/index.ts
+++ b/lib/consent-cookies/src/index.ts
@@ -97,7 +97,7 @@ export const consentCookies = ({
           path: '/', // Cover entire site
           domain: undefined, // Do NOT cover subdomains (yes, really)
           sameSite: 'strict', // Some CSRF protection
-          secure: process.env['NODE_ENV'] === 'production', // Require TLS in production
+          secure: true, // Require TLS
           ...defaults,
           ...declaration,
           ...options,

--- a/lib/consent-cookies/src/index.ts
+++ b/lib/consent-cookies/src/index.ts
@@ -117,11 +117,6 @@ export const consentCookies = ({
     res.setCookie = setCookie;
     res.setCookieConsent = setCookieConsent;
 
-    // Set initial consent cookie if required
-    if (_consent === undefined) {
-      res.setCookieConsent([]);
-    }
-
     provideSession ? sessions(req, res, next) : next();
   }
 };

--- a/lib/consent-cookies/src/sessions.ts
+++ b/lib/consent-cookies/src/sessions.ts
@@ -7,7 +7,8 @@ type WriteHead = (statusCode: number, statusMessage?: string | Headers, headers?
 export const sessionCookie: Cookie = {
   name: 'session',
   description: 'Your session on this website.',
-  httpOnly: true // No access from JavaScript
+  httpOnly: true, // No access from JavaScript
+  sameSite: 'lax' // Some sane CSRF protection
 };
 
 export const sessions: Middleware = (req, res, next) => {
@@ -47,12 +48,7 @@ export const sessions: Middleware = (req, res, next) => {
   const _writeHead: WriteHead = res.writeHead.bind(res);
   const writeHead: WriteHead = function (statusCode, statusMessage, headers) {
     if (modified) {
-      this.setCookie(sessionCookie.name, req.session, {
-        path: '/', // Cover entire site
-        domain: undefined, // Do NOT cover subdomains (yes, really)
-        sameSite: 'lax', // Some sane CSRF protection
-        secure: process.env['NODE_ENV'] === 'production', // Require TLS in production
-      })
+      this.setCookie(sessionCookie.name, req.session)
     }
 
     return _writeHead(statusCode, statusMessage, headers);

--- a/lib/consent-cookies/src/sessions.ts
+++ b/lib/consent-cookies/src/sessions.ts
@@ -1,0 +1,66 @@
+import type { Cookie, Middleware } from './common';
+import type { OutgoingHttpHeader, OutgoingHttpHeaders, ServerResponse } from 'http';
+
+type Headers = OutgoingHttpHeaders | OutgoingHttpHeader[];
+type WriteHead = (statusCode: number, statusMessage?: string | Headers, headers?: Headers) => ServerResponse;
+
+export const sessionCookie: Cookie = {
+  name: 'session',
+  description: 'Your session on this website.',
+  httpOnly: true // No access from JavaScript
+};
+
+export const sessions: Middleware = (req, res, next) => {
+  // Look for an existing session
+  const rawData = req.cookies[sessionCookie.name];
+  const sessionData: object = (
+    rawData && typeof rawData === 'object'
+      ? req.cookies[sessionCookie.name]
+      : {}
+  );
+
+  // Make session data available on the request
+  let modified = false;
+  const handler = {
+    get(target, prop, receiver) {
+      const sub = target[prop];
+      return (
+        typeof sub === 'object' && sub !== null
+          ? new Proxy(target[prop], handler)
+          : Reflect.get(target, prop, receiver)
+      );
+    },
+    deleteProperty(target, prop) {
+      modified = true;
+
+      return Reflect.deleteProperty(target, prop);
+    },
+    set(target, prop, receiver) {
+      modified = true;
+
+      return Reflect.set(target, prop, receiver);
+    }
+  };
+  req.session = new Proxy(sessionData, handler);
+
+  // Write the session before we send headers
+  const _writeHead: WriteHead = res.writeHead.bind(res);
+  const writeHead: WriteHead = function (statusCode, statusMessage, headers) {
+    if (modified) {
+      this.setCookie(sessionCookie.name, req.session, {
+        path: '/', // Cover entire site
+        domain: undefined, // Do NOT cover subdomains (yes, really)
+        sameSite: 'lax', // Some sane CSRF protection
+        secure: process.env['NODE_ENV'] === 'production', // Require TLS in production
+      })
+    }
+
+    return _writeHead(statusCode, statusMessage, headers);
+  };
+
+  res.writeHead = writeHead;
+
+  next();
+}
+
+export default sessions;

--- a/lib/consent-cookies/tsconfig.json
+++ b/lib/consent-cookies/tsconfig.json
@@ -1,0 +1,1 @@
+../plop-pack/skel/lib/tsconfig.json

--- a/lib/engine/package.json
+++ b/lib/engine/package.json
@@ -19,12 +19,12 @@
   "author": "Daniel A.C. Martin <npm@daniel-martin.co.uk> (http://daniel-martin.co.uk/)",
   "license": "MIT",
   "dependencies": {
+    "@not-govuk/consent-cookies": "workspace:^0.4.2",
     "@not-govuk/express-adapter": "workspace:^0.4.2",
     "@not-govuk/restify": "workspace:^0.4.0",
     "@not-govuk/server-renderer": "workspace:^0.4.0",
     "apollo-server-restify": "^1.3.6",
     "base64url": "^3.0.1",
-    "client-sessions": "^0.8.0",
     "openid-client": "^5.0.0",
     "passport": "^0.6.0",
     "passport-http": "^0.3.0",

--- a/lib/engine/src/index.ts
+++ b/lib/engine/src/index.ts
@@ -64,7 +64,7 @@ export const engine = async ({
   PageWrap,
   apis,
   assets,
-  auth: _auth,
+  auth: authOptions,
   env,
   graphQL: _graphQL,
   httpd: { host, port },
@@ -88,11 +88,11 @@ export const engine = async ({
     )
   };
 
-  const signInOut = _auth && !([
+  const signInOut = authOptions && !([
     AuthMethod.None,
     AuthMethod.Dummy,
     AuthMethod.Headers
-  ].includes(_auth.method))
+  ].includes(authOptions.method))
   const signInHRef = (
     signInOut
       ? '/auth/sign-in'
@@ -136,8 +136,8 @@ export const engine = async ({
   httpd.use(react.renderer);
 
   // Gather auth information
-  if (_auth) {
-    const { apply: applyAuth } = await auth(_auth);
+  if (authOptions) {
+    const { apply: applyAuth } = await auth(authOptions);
 
     applyAuth(httpd, privacy);
   }

--- a/lib/engine/src/index.ts
+++ b/lib/engine/src/index.ts
@@ -235,4 +235,5 @@ export const engine = async ({
 export default engine;
 export { AuthMethod };
 export { Router, errors } from '@not-govuk/restify';
+export { defaultsFalse, defaultsTrue } from './lib/config-helpers';
 export type { IsReady };

--- a/lib/engine/src/index.ts
+++ b/lib/engine/src/index.ts
@@ -39,7 +39,10 @@ export type EngineOptions = {
   apis?: Api[]
   assets: Assets
   auth?: AuthOptions
-  encryptionSecret: string
+  cookies: {
+    secret: string
+    secure?: boolean
+  }
   env: NodeEnv
   graphQL?: {
     schema: GraphQLSchema
@@ -67,7 +70,7 @@ export const engine = async ({
   apis,
   assets,
   auth: authOptions,
-  encryptionSecret,
+  cookies: cookieOptions,
   env,
   graphQL: _graphQL,
   httpd: { host, port },
@@ -154,8 +157,9 @@ export const engine = async ({
 
   httpd.use(consentCookies({
     cookies,
-    secret: encryptionSecret,
-    provideSession: sessions
+    provideSession: sessions,
+    secret: cookieOptions.secret,
+    secure: cookieOptions.secure
   }));
 
   if (applyAuth) {

--- a/lib/engine/src/lib/auth/basic.ts
+++ b/lib/engine/src/lib/auth/basic.ts
@@ -10,7 +10,6 @@ export type AuthOptionsBasic = {
   username: string
   password: string
   roles?: string[]
-  sessionsSecret: string
 };
 
 export type AuthInfo = UserProfile & {
@@ -19,7 +18,6 @@ export type AuthInfo = UserProfile & {
 export const basicAuth: AuthBagger<AuthOptionsBasic> = async ({
   password,
   roles = [],
-  sessionsSecret,
   username
 }) => {
   const verify = (suppliedUsername, suppliedPassword, done) => {
@@ -43,7 +41,6 @@ export const basicAuth: AuthBagger<AuthOptionsBasic> = async ({
     callback: false,
     id: 'basic',
     sessions: true,
-    sessionsSecret,
     strategy
   });
 };

--- a/lib/engine/src/lib/auth/common.ts
+++ b/lib/engine/src/lib/auth/common.ts
@@ -1,5 +1,7 @@
 import { Next, Request as _Request, Response, Server } from 'restify';
 
+import type { Cookie } from '@not-govuk/consent-cookies';
+
 export enum AuthMethod {
   None = 'none',
   Dummy = 'dummy',
@@ -40,7 +42,9 @@ export type AuthBag = {
   apply?: Apply
   authenticate?: Middleware
   callback?: Middleware
+  cookies?: Cookie[]
   extractor?: UserExtractor
+  sessions?: boolean
   terminate?: Middleware
 };
 

--- a/lib/engine/src/lib/auth/oidc.ts
+++ b/lib/engine/src/lib/auth/oidc.ts
@@ -11,7 +11,6 @@ export type AuthOptionsOIDC = {
   clientId: string
   clientSecret?: string
   redirectUri: string
-  sessionsSecret: string
 };
 
 export type AuthInfo = UserProfile & {
@@ -31,8 +30,7 @@ export const oidcAuth: AuthBagger<AuthOptionsOIDC> = async ({
   clientId,
   clientSecret,
   issuer,
-  redirectUri,
-  sessionsSecret
+  redirectUri
 }) => {
   custom.setHttpOptionsDefaults({
     timeout: 5000,
@@ -108,7 +106,6 @@ export const oidcAuth: AuthBagger<AuthOptionsOIDC> = async ({
     callback: true,
     id: 'oidc',
     sessions: true,
-    sessionsSecret,
     strategy
   });
 };

--- a/lib/engine/src/lib/config-helpers.ts
+++ b/lib/engine/src/lib/config-helpers.ts
@@ -1,0 +1,10 @@
+type Pattern = RegExp | string;
+
+const parseBoolean = (pattern: Pattern) => (
+  (s: string): boolean => !!(
+    s && s.match(pattern)
+  )
+);
+
+export const defaultsFalse = parseBoolean(/(yes|on|true|1)/i);
+export const defaultsTrue = parseBoolean(/(no|off|false|0)/i);

--- a/lib/plop-pack/skel/app/package.json.hbs
+++ b/lib/plop-pack/skel/app/package.json.hbs
@@ -6,10 +6,11 @@
   "main": "dist/server/index.js",
   "scripts": {
     "start": "node .",
+    "start:test": "COOKIES_SECURE=no node .",
     "test": "npm run test:unit",
     "test:ci": "npm test && npm run test:functional:ci",
     "test:functional": "cypress run ${CYPRESS_PROJECT_ID:+--record ${CYPRESS_FLAGS}}",
-    "test:functional:ci": "start-server-and-test start 'http-get://localhost:8080/readiness' test:functional",
+    "test:functional:ci": "start-server-and-test 'start:test' 'http-get://localhost:8080/readiness' test:functional",
     "test:unit": "jest --passWithNoTests",
     "build": "webpack",
     "package:aws-lambda": "sls package -c aws.serverless.yml -p pkg/aws-lambda",

--- a/lib/plop-pack/skel/app/src/server/config.ts
+++ b/lib/plop-pack/skel/app/src/server/config.ts
@@ -1,4 +1,4 @@
-import { AuthMethod, Mode, NodeEnv } from '@not-govuk/engine';
+import { AuthMethod, Mode, NodeEnv, defaultsFalse, defaultsTrue } from '@not-govuk/engine';
 import commonConfig from '../common/config';
 
 const env = process.env.NODE_ENV as NodeEnv;
@@ -31,7 +31,10 @@ const serverConfig = {
       redirectUri: process.env.OIDC_REDIRECT_URI || 'http://localhost:8080'
     }
   },
-  encryptionSecret: process.env.ENCRYPTION_SECRET || 'changeme',
+  cookies: {
+    secret: process.env.COOKIES_SECRET || 'changeme',
+    secure: ( devMode ? defaultsFalse : defaultsTrue )(process.env.COOKIES_SECURE)
+  },
   env,
   logger: {
     destination: process.env.LOG_DESTINATION,
@@ -42,8 +45,8 @@ const serverConfig = {
     port: Number(process.env.PORT) || Number(process.env.LISTEN_PORT) || 8080
   },
   mode: (process.env.MODE || 'server') as Mode,
-  privacy: !!(process.env.PRIVACY && process.env.PRIVACY.match(/(yes|true)/i)),
-  ssrOnly: !!(process.env.SSR_ONLY && process.env.SSR_ONLY.match(/(yes|true)/i))
+  privacy: defaultsFalse(process.env.PRIVACY),
+  ssrOnly: defaultsFalse(process.env.SSR_ONLY)
 };
 
 export default serverConfig;

--- a/lib/plop-pack/skel/app/src/server/config.ts
+++ b/lib/plop-pack/skel/app/src/server/config.ts
@@ -9,7 +9,6 @@ const serverConfig = {
   ...commonConfig,
   auth: {
     method: process.env.AUTH_METHOD || ( devMode ? AuthMethod.Dummy : AuthMethod.Basic ),
-    sessionsSecret: process.env.SESSIONS_SECRET || 'changeme',
     dummy: {
       username: 'TestUser',
       groups: [],
@@ -32,6 +31,7 @@ const serverConfig = {
       redirectUri: process.env.OIDC_REDIRECT_URI || 'http://localhost:8080'
     }
   },
+  encryptionSecret: process.env.ENCRYPTION_SECRET || 'changeme',
   env,
   logger: {
     destination: process.env.LOG_DESTINATION,

--- a/lib/plop-pack/skel/app/src/server/httpd.ts
+++ b/lib/plop-pack/skel/app/src/server/httpd.ts
@@ -27,9 +27,10 @@ export const createServer = ({ entrypoints, port }: httpdOptions) => {
       ( config.auth.method === AuthMethod.None && { method: AuthMethod.None } )
         || ( config.auth.method === AuthMethod.Dummy && { method: AuthMethod.Dummy, ...config.auth.dummy } )
         || ( config.auth.method === AuthMethod.Headers && { method: AuthMethod.Headers, ...config.auth.headers } )
-        || ( config.auth.method === AuthMethod.Basic && { method: AuthMethod.Basic, ...config.auth.basic, sessionsSecret: config.auth.sessionsSecret } )
-        || ( config.auth.method === AuthMethod.OIDC && { method: AuthMethod.OIDC, ...config.auth.oidc, sessionsSecret: config.auth.sessionsSecret } )
+        || ( config.auth.method === AuthMethod.Basic && { method: AuthMethod.Basic, ...config.auth.basic } )
+        || ( config.auth.method === AuthMethod.OIDC && { method: AuthMethod.OIDC, ...config.auth.oidc } )
     ),
+    encryptionSecret: config.encryptionSecret,
     env: config.env,
     graphQL: {
       schema: graphQLSchema

--- a/lib/plop-pack/skel/app/src/server/httpd.ts
+++ b/lib/plop-pack/skel/app/src/server/httpd.ts
@@ -30,7 +30,10 @@ export const createServer = ({ entrypoints, port }: httpdOptions) => {
         || ( config.auth.method === AuthMethod.Basic && { method: AuthMethod.Basic, ...config.auth.basic } )
         || ( config.auth.method === AuthMethod.OIDC && { method: AuthMethod.OIDC, ...config.auth.oidc } )
     ),
-    encryptionSecret: config.encryptionSecret,
+    cookies: {
+      secret: config.cookies.secret,
+      secure: config.cookies.secure
+    },
     env: config.env,
     graphQL: {
       schema: graphQLSchema

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
       '@not-govuk/user-info': link:lib/user-info
       '@storybook/addon-a11y': 6.5.6_react-dom@16.14.0+react@16.14.0
       '@storybook/addon-actions': 6.5.6_react-dom@16.14.0+react@16.14.0
-      '@storybook/addon-docs': 6.5.6_6acaf03e527587ad64c8af1fc2cfb6d7
+      '@storybook/addon-docs': 6.5.6_94b00537cc0eb74b160fc8634f81acfb
       '@storybook/addon-jest': 6.5.6_react-dom@16.14.0+react@16.14.0
       '@storybook/addon-links': 6.5.6_react-dom@16.14.0+react@16.14.0
       '@storybook/addon-storysource': 6.5.6_react-dom@16.14.0+react@16.14.0
@@ -1504,6 +1504,29 @@ importers:
       '@types/react-router': 5.1.18
       typescript: 4.6.4
 
+  lib/consent-cookies:
+    specifiers:
+      '@types/connect': ^3.4.35
+      '@types/cookie': ^0.5.1
+      '@types/cryptr': ^4.0.1
+      cookie: ^0.5.0
+      cryptr: ^6.0.3
+      jest: 28.1.0
+      jest-environment-jsdom: 28.1.0
+      ts-jest: 28.0.2
+      typescript: 4.6.4
+    dependencies:
+      cookie: 0.5.0
+      cryptr: 6.0.3
+    devDependencies:
+      '@types/connect': 3.4.35
+      '@types/cookie': 0.5.1
+      '@types/cryptr': 4.0.1
+      jest: 28.1.0
+      jest-environment-jsdom: 28.1.0
+      ts-jest: 28.0.2_823136af10737b04809fd90c6c630aeb
+      typescript: 4.6.4
+
   lib/create:
     specifiers:
       '@not-govuk/plop-pack-internal': workspace:^0.4.0
@@ -1543,6 +1566,7 @@ importers:
   lib/engine:
     specifiers:
       '@not-govuk/app-composer': workspace:^0.4.0
+      '@not-govuk/consent-cookies': workspace:^0.4.2
       '@not-govuk/express-adapter': workspace:^0.4.2
       '@not-govuk/restify': workspace:^0.4.0
       '@not-govuk/server-renderer': workspace:^0.4.0
@@ -1552,7 +1576,6 @@ importers:
       '@types/restify': 8.5.4
       apollo-server-restify: ^1.3.6
       base64url: ^3.0.1
-      client-sessions: ^0.8.0
       graphql: 15.8.0
       openid-client: ^5.0.0
       passport: ^0.6.0
@@ -1560,12 +1583,12 @@ importers:
       serverless-http: ^3.0.0
       typescript: 4.6.4
     dependencies:
+      '@not-govuk/consent-cookies': link:../consent-cookies
       '@not-govuk/express-adapter': link:../express-adapter
       '@not-govuk/restify': link:../restify
       '@not-govuk/server-renderer': link:../server-renderer
       apollo-server-restify: 1.3.6_graphql@15.8.0
       base64url: 3.0.1
-      client-sessions: 0.8.0
       openid-client: 5.1.6
       passport: 0.6.0
       passport-http: 0.3.0
@@ -2051,29 +2074,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/core/7.18.0:
-    resolution: {integrity: sha512-Xyw74OlJwDijToNi0+6BBI5mLLR5+5R3bcSH80LXzjzEGEUlvNzujEE71BaD/ApEZHAvFI/Mlmp4M5lIkdeeWw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.1.2
-      '@babel/code-frame': 7.16.7
-      '@babel/generator': 7.18.0
-      '@babel/helper-compilation-targets': 7.17.10_@babel+core@7.18.0
-      '@babel/helper-module-transforms': 7.18.0
-      '@babel/helpers': 7.18.0
-      '@babel/parser': 7.18.0
-      '@babel/template': 7.16.7
-      '@babel/traverse': 7.18.0
-      '@babel/types': 7.18.0
-      convert-source-map: 1.8.0
-      debug: 4.3.3
-      gensync: 1.0.0-beta.2
-      json5: 2.2.1
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/core/7.18.2:
     resolution: {integrity: sha512-A8pri1YJiC5UnkdrWcmfZTJTV85b4UXTAfImGmCfYmax4TR9Cw8sDS0MOk++Gp2mE/BefVJ5nwy5yzqNJbP/DQ==}
     engines: {node: '>=6.9.0'}
@@ -2112,15 +2112,6 @@ packages:
       jsesc: 2.5.2
       source-map: 0.5.7
     dev: false
-
-  /@babel/generator/7.18.0:
-    resolution: {integrity: sha512-81YO9gGx6voPXlvYdZBliFXAZU8vZ9AZ6z+CjlmcnaeOcYSFbMTpdeDUO9xD9dh/68Vq03I8ZspfUTPfitcDHg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.18.0
-      '@jridgewell/gen-mapping': 0.3.1
-      jsesc: 2.5.2
-    dev: true
 
   /@babel/generator/7.18.2:
     resolution: {integrity: sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==}
@@ -2179,19 +2170,6 @@ packages:
       levenary: 1.1.1
       semver: 5.7.1
     dev: false
-
-  /@babel/helper-compilation-targets/7.17.10_@babel+core@7.18.0:
-    resolution: {integrity: sha512-gh3RxjWbauw/dFiU/7whjd0qN9K6nPJMqe6+Er7rOavFh0CQUSwhAE3IcTho2rywPJFxej6TUUHDkWcYI6gGqQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.17.10
-      '@babel/core': 7.18.0
-      '@babel/helper-validator-option': 7.16.7
-      browserslist: 4.20.3
-      semver: 6.3.0
-    dev: true
 
   /@babel/helper-compilation-targets/7.18.2_@babel+core@7.18.2:
     resolution: {integrity: sha512-s1jnPotJS9uQnzFtiZVBUxe67CuBa679oWFHpxYYnTpRL/1ffhyX44R9uYiXoa/pLXcY9H2moJta0iaanlk/rQ==}
@@ -2324,6 +2302,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.18.0
+    dev: false
 
   /@babel/helper-environment-visitor/7.18.2:
     resolution: {integrity: sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ==}
@@ -2549,17 +2528,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
-
-  /@babel/helpers/7.18.0:
-    resolution: {integrity: sha512-AE+HMYhmlMIbho9nbvicHyxFwhrO+xhKB6AhRxzl8w46Yj0VXTZjEsAoBVC7rB2I0jzX+yWyVybnO08qkfx6kg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.16.7
-      '@babel/traverse': 7.18.0
-      '@babel/types': 7.18.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@babel/helpers/7.18.2:
     resolution: {integrity: sha512-j+d+u5xT5utcQSzrh9p+PaJX94h++KN+ng9b9WEJq7pkUPAd61FGqhjuUEdfknb3E/uDBb7ruwEeKkIxNJPIrg==}
@@ -2964,15 +2932,6 @@ packages:
       '@babel/helper-plugin-utils': 7.17.12
     dev: false
 
-  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.18.0:
-    resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.17.12
-    dev: true
-
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.18.2:
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
@@ -2980,15 +2939,6 @@ packages:
     dependencies:
       '@babel/core': 7.18.2
       '@babel/helper-plugin-utils': 7.17.12
-
-  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.18.0:
-    resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.17.12
-    dev: true
 
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.18.2:
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
@@ -3007,15 +2957,6 @@ packages:
       '@babel/core': 7.10.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: false
-
-  /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.18.0:
-    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.17.12
-    dev: true
 
   /@babel/plugin-syntax-class-properties/7.12.13_@babel+core@7.18.2:
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
@@ -3104,15 +3045,6 @@ packages:
       '@babel/core': 7.18.2
       '@babel/helper-plugin-utils': 7.17.12
 
-  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.18.0:
-    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.17.12
-    dev: true
-
   /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.18.2:
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
     peerDependencies:
@@ -3130,15 +3062,6 @@ packages:
       '@babel/core': 7.10.5
       '@babel/helper-plugin-utils': 7.17.12
     dev: false
-
-  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.18.0:
-    resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.17.12
-    dev: true
 
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.18.2:
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
@@ -3174,15 +3097,6 @@ packages:
       '@babel/core': 7.18.2
       '@babel/helper-plugin-utils': 7.17.12
 
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.18.0:
-    resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.17.12
-    dev: true
-
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.18.2:
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
@@ -3200,15 +3114,6 @@ packages:
       '@babel/helper-plugin-utils': 7.17.12
     dev: false
 
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.18.0:
-    resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.17.12
-    dev: true
-
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.18.2:
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
@@ -3225,15 +3130,6 @@ packages:
       '@babel/core': 7.10.5
       '@babel/helper-plugin-utils': 7.17.12
     dev: false
-
-  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.18.0:
-    resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.17.12
-    dev: true
 
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.18.2:
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
@@ -3260,15 +3156,6 @@ packages:
       '@babel/core': 7.12.9
       '@babel/helper-plugin-utils': 7.17.12
 
-  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.18.0:
-    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.17.12
-    dev: true
-
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.18.2:
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
@@ -3286,15 +3173,6 @@ packages:
       '@babel/helper-plugin-utils': 7.17.12
     dev: false
 
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.18.0:
-    resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.17.12
-    dev: true
-
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.18.2:
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
@@ -3311,15 +3189,6 @@ packages:
       '@babel/core': 7.10.5
       '@babel/helper-plugin-utils': 7.17.12
     dev: false
-
-  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.18.0:
-    resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.17.12
-    dev: true
 
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.18.2:
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
@@ -3347,16 +3216,6 @@ packages:
       '@babel/helper-plugin-utils': 7.16.7
     dev: false
 
-  /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.18.0:
-    resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.17.12
-    dev: true
-
   /@babel/plugin-syntax-top-level-await/7.14.5_@babel+core@7.18.2:
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
@@ -3374,16 +3233,6 @@ packages:
       '@babel/core': 7.10.5
       '@babel/helper-plugin-utils': 7.16.7
     dev: false
-
-  /@babel/plugin-syntax-typescript/7.17.12_@babel+core@7.18.0:
-    resolution: {integrity: sha512-TYY0SXFiO31YXtNg3HtFwNJHjLsAyIIhAhNWkQ5whPPS7HWUFlg9z0Ta4qAQNjQbP1wsSt/oKkmZ/4/WWdMUpw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/helper-plugin-utils': 7.17.12
-    dev: true
 
   /@babel/plugin-syntax-typescript/7.17.12_@babel+core@7.18.2:
     resolution: {integrity: sha512-TYY0SXFiO31YXtNg3HtFwNJHjLsAyIIhAhNWkQ5whPPS7HWUFlg9z0Ta4qAQNjQbP1wsSt/oKkmZ/4/WWdMUpw==}
@@ -4508,24 +4357,6 @@ packages:
       - supports-color
     dev: false
 
-  /@babel/traverse/7.17.12:
-    resolution: {integrity: sha512-zULPs+TbCvOkIFd4FrG53xrpxvCBwLIgo6tO0tJorY7YV2IWFxUfS/lXDJbGgfyYt9ery/Gxj2niwttNnB0gIw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.16.7
-      '@babel/generator': 7.18.0
-      '@babel/helper-environment-visitor': 7.16.7
-      '@babel/helper-function-name': 7.17.9
-      '@babel/helper-hoist-variables': 7.16.7
-      '@babel/helper-split-export-declaration': 7.16.7
-      '@babel/parser': 7.18.0
-      '@babel/types': 7.18.0
-      debug: 4.3.3
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/traverse/7.17.3:
     resolution: {integrity: sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==}
     engines: {node: '>=6.9.0'}
@@ -4543,24 +4374,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
-
-  /@babel/traverse/7.18.0:
-    resolution: {integrity: sha512-oNOO4vaoIQoGjDQ84LgtF/IAlxlyqL4TUuoQ7xLkQETFaHkY1F7yazhB4Kt3VcZGL0ZF/jhrEpnXqUb0M7V3sw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.16.7
-      '@babel/generator': 7.18.0
-      '@babel/helper-environment-visitor': 7.16.7
-      '@babel/helper-function-name': 7.17.9
-      '@babel/helper-hoist-variables': 7.16.7
-      '@babel/helper-split-export-declaration': 7.16.7
-      '@babel/parser': 7.18.0
-      '@babel/types': 7.18.0
-      debug: 4.3.3
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@babel/traverse/7.18.2:
     resolution: {integrity: sha512-9eNwoeovJ6KH9zcCNnENY7DMFwTU9JdGCFtqNLfUAqtUHRCOsTOqWoffosP8vKmNYeSBUv3yVJXjfd8ucwOjUA==}
@@ -4601,6 +4414,7 @@ packages:
     dependencies:
       '@babel/helper-validator-identifier': 7.16.7
       to-fast-properties: 2.0.0
+    dev: false
 
   /@babel/types/7.18.2:
     resolution: {integrity: sha512-0On6B8A4/+mFUto5WERt3EEuG1NznDirvwca1O8UwXQHVY8g3R7OzYgxXdOfMwLO08UrpUD/2+3Bclyq+/C94Q==}
@@ -4648,13 +4462,11 @@ packages:
       uuid: 8.3.2
     dev: true
 
-  /@cypress/xvfb/1.2.4_supports-color@8.1.1:
+  /@cypress/xvfb/1.2.4:
     resolution: {integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==}
     dependencies:
-      debug: 3.2.7_supports-color@8.1.1
+      debug: 3.2.7
       lodash.once: 4.1.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@discoveryjs/json-ext/0.5.7:
@@ -5401,7 +5213,7 @@ packages:
       uuid-browser: 3.1.0
     dev: true
 
-  /@storybook/addon-docs/6.5.6_6acaf03e527587ad64c8af1fc2cfb6d7:
+  /@storybook/addon-docs/6.5.6_94b00537cc0eb74b160fc8634f81acfb:
     resolution: {integrity: sha512-18MOB4Cvr10ibRlA58Y2MqaC0EM9NG758iSjweThaU4kZtSBSDn8R2qBLDGQPwEFkww+4+oAFXxR5/J0qO2xEw==}
     peerDependencies:
       '@storybook/mdx2-csf': ^0.0.3
@@ -5422,7 +5234,7 @@ packages:
       '@storybook/addons': 6.5.6_react-dom@16.14.0+react@16.14.0
       '@storybook/api': 6.5.6_react-dom@16.14.0+react@16.14.0
       '@storybook/components': 6.5.6_react-dom@16.14.0+react@16.14.0
-      '@storybook/core-common': 6.5.6_6cc04611407a90b373e458ffdd9c2500
+      '@storybook/core-common': 6.5.6_1596ec9896079968c237ec0328822914
       '@storybook/core-events': 6.5.6
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.6_react-dom@16.14.0+react@16.14.0
@@ -5452,8 +5264,6 @@ packages:
       - typescript
       - vue-template-compiler
       - webpack
-      - webpack-cli
-      - webpack-command
     dev: true
 
   /@storybook/addon-jest/6.5.6_react-dom@16.14.0+react@16.14.0:
@@ -5609,7 +5419,7 @@ packages:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  /@storybook/builder-webpack4/6.5.6_6cc04611407a90b373e458ffdd9c2500:
+  /@storybook/builder-webpack4/6.5.6_1596ec9896079968c237ec0328822914:
     resolution: {integrity: sha512-/nACQ5SoddCs1geGUKXrrXiYDvYdTVXWXc0L6mXawjYANBeWIkAKFlhRpoXGN/KiFuuExO2+UgNCKlUyD0a51Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5627,7 +5437,7 @@ packages:
       '@storybook/client-api': 6.5.6_react-dom@16.14.0+react@16.14.0
       '@storybook/client-logger': 6.5.6
       '@storybook/components': 6.5.6_react-dom@16.14.0+react@16.14.0
-      '@storybook/core-common': 6.5.6_6cc04611407a90b373e458ffdd9c2500
+      '@storybook/core-common': 6.5.6_1596ec9896079968c237ec0328822914
       '@storybook/core-events': 6.5.6
       '@storybook/node-logger': 6.5.6
       '@storybook/preview-web': 6.5.6_react-dom@16.14.0+react@16.14.0
@@ -5645,7 +5455,7 @@ packages:
       css-loader: 3.6.0_webpack@4.43.0
       file-loader: 6.2.0_webpack@4.43.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6_typescript@4.6.4+webpack@4.43.0
+      fork-ts-checker-webpack-plugin: 4.1.6
       glob: 7.2.0
       glob-promise: 3.4.0_glob@7.2.0
       global: 4.4.0
@@ -5664,18 +5474,15 @@ packages:
       typescript: 4.6.4
       url-loader: 4.1.1_file-loader@6.2.0+webpack@4.43.0
       util-deprecate: 1.0.2
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
       webpack-dev-middleware: 3.7.3_webpack@4.43.0
       webpack-filter-warnings-plugin: 1.2.1_webpack@4.43.0
       webpack-hot-middleware: 2.25.1
       webpack-virtual-modules: 0.2.2
     transitivePeerDependencies:
-      - bluebird
       - eslint
       - supports-color
       - vue-template-compiler
-      - webpack-cli
-      - webpack-command
 
   /@storybook/builder-webpack5/6.5.6_6cc04611407a90b373e458ffdd9c2500:
     resolution: {integrity: sha512-inR1xh16barDutfoxv8MCTQTztASLpewDsu6YDs87ifYlYfWuS/NlbY290EWj4D8je1LY53Rpbpkorj/49wCeA==}
@@ -5695,7 +5502,7 @@ packages:
       '@storybook/client-api': 6.5.6_react-dom@16.14.0+react@16.14.0
       '@storybook/client-logger': 6.5.6
       '@storybook/components': 6.5.6_react-dom@16.14.0+react@16.14.0
-      '@storybook/core-common': 6.5.6_6cc04611407a90b373e458ffdd9c2500
+      '@storybook/core-common': 6.5.6_1596ec9896079968c237ec0328822914
       '@storybook/core-events': 6.5.6
       '@storybook/node-logger': 6.5.6
       '@storybook/preview-web': 6.5.6_react-dom@16.14.0+react@16.14.0
@@ -5736,7 +5543,7 @@ packages:
       - uglify-js
       - vue-template-compiler
       - webpack-cli
-      - webpack-command
+    dev: true
 
   /@storybook/channel-postmessage/6.5.6:
     resolution: {integrity: sha512-kyYO84hItSE1SaEI1xpMYqJOM3MJ2Y2WHx1Hxu5prq2T2cIgUGURyNf3+5G0BLTf2XGNEN/7YYv9rHmQ9GUz8g==}
@@ -5853,6 +5660,7 @@ packages:
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 5.73.0_webpack-cli@4.9.2
+    dev: true
 
   /@storybook/core-client/6.5.6_dde788d947c79adfe193fcb1e6bf6ea4:
     resolution: {integrity: sha512-Xmjt95GYYVRp7ra49Y955BLH/FYlOmuLC4aFTGurjmCay7zUqvExxFk9AUKOkyBb1/S/8iQCG59D0ES6YWoMRw==}
@@ -5888,7 +5696,7 @@ packages:
       typescript: 4.6.4
       unfetch: 4.2.0
       util-deprecate: 1.0.2
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
 
   /@storybook/core-client/6.5.6_ebec5c77535b3b959d7127b093a022cf:
     resolution: {integrity: sha512-Xmjt95GYYVRp7ra49Y955BLH/FYlOmuLC4aFTGurjmCay7zUqvExxFk9AUKOkyBb1/S/8iQCG59D0ES6YWoMRw==}
@@ -5926,7 +5734,7 @@ packages:
       util-deprecate: 1.0.2
       webpack: 5.72.1_webpack-cli@4.9.2
 
-  /@storybook/core-common/6.5.6_6cc04611407a90b373e458ffdd9c2500:
+  /@storybook/core-common/6.5.6_1596ec9896079968c237ec0328822914:
     resolution: {integrity: sha512-+k+D9CzyFHNAy59jt2sfKnb/KU/nXO1hvBVaJAhdocjrDMvHtwYuXWWQrWYX3/VGp9wCa9TC0JG1kz+DWSYXaQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -5988,20 +5796,18 @@ packages:
       ts-dedent: 2.2.0
       typescript: 4.6.4
       util-deprecate: 1.0.2
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
     transitivePeerDependencies:
       - eslint
       - supports-color
       - vue-template-compiler
-      - webpack-cli
-      - webpack-command
 
   /@storybook/core-events/6.5.6:
     resolution: {integrity: sha512-bzktgM1i0QPrayH1ANbKb7nYpehSpi5QHWps2vVQbvtpI/pGlTtpde1e87vfAt74Bvsvd3/9IpQkQKteDODAkA==}
     dependencies:
       core-js: 3.21.1
 
-  /@storybook/core-server/6.5.6_1820b51c503d59a7c034bf72c4402c5d:
+  /@storybook/core-server/6.5.6_f678faad3866296bb5c8f14d548144a4:
     resolution: {integrity: sha512-65kwbSXsKPl/0BKjGr9RTihv6jYGGIG/prfLscZPtm3u4/Z8ZxCX94rznztxcUatjLlUfKJ8iimizhUOIa0FJA==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -6018,19 +5824,19 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.5.6_6cc04611407a90b373e458ffdd9c2500
+      '@storybook/builder-webpack4': 6.5.6_1596ec9896079968c237ec0328822914
       '@storybook/builder-webpack5': 6.5.6_6cc04611407a90b373e458ffdd9c2500
       '@storybook/core-client': 6.5.6_dde788d947c79adfe193fcb1e6bf6ea4
-      '@storybook/core-common': 6.5.6_6cc04611407a90b373e458ffdd9c2500
+      '@storybook/core-common': 6.5.6_1596ec9896079968c237ec0328822914
       '@storybook/core-events': 6.5.6
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/csf-tools': 6.5.6
-      '@storybook/manager-webpack4': 6.5.6_6cc04611407a90b373e458ffdd9c2500
+      '@storybook/manager-webpack4': 6.5.6_1596ec9896079968c237ec0328822914
       '@storybook/manager-webpack5': 6.5.6_6cc04611407a90b373e458ffdd9c2500
       '@storybook/node-logger': 6.5.6
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.6_react-dom@16.14.0+react@16.14.0
-      '@storybook/telemetry': 6.5.6_6cc04611407a90b373e458ffdd9c2500
+      '@storybook/telemetry': 6.5.6_1596ec9896079968c237ec0328822914
       '@types/node': 16.11.36
       '@types/node-fetch': 2.6.1
       '@types/pretty-hrtime': 1.0.1
@@ -6064,22 +5870,19 @@ packages:
       typescript: 4.6.4
       util-deprecate: 1.0.2
       watchpack: 2.3.1
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
       ws: 8.5.0
       x-default-browser: 0.4.0
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
-      - bluebird
       - bufferutil
       - encoding
       - eslint
       - supports-color
       - utf-8-validate
       - vue-template-compiler
-      - webpack-cli
-      - webpack-command
 
-  /@storybook/core/6.5.6_f05ea00584b166a2fb5b13fa151cfab0:
+  /@storybook/core/6.5.6_d9b4b98ca8479c4866a60963afdf1772:
     resolution: {integrity: sha512-DS6Q8SrEXBDoDS2K865NoWggSXEg8L9p+jx8sILLkLrr2QXJT0x6YIFSwEh6rGwkahxDV5ikON/rW39Wlxzk1w==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -6098,7 +5901,7 @@ packages:
     dependencies:
       '@storybook/builder-webpack5': 6.5.6_6cc04611407a90b373e458ffdd9c2500
       '@storybook/core-client': 6.5.6_ebec5c77535b3b959d7127b093a022cf
-      '@storybook/core-server': 6.5.6_1820b51c503d59a7c034bf72c4402c5d
+      '@storybook/core-server': 6.5.6_f678faad3866296bb5c8f14d548144a4
       '@storybook/manager-webpack5': 6.5.6_6cc04611407a90b373e458ffdd9c2500
       react: 16.14.0
       react-dom: 16.14.0_react@16.14.0
@@ -6106,15 +5909,12 @@ packages:
       webpack: 5.72.1_webpack-cli@4.9.2
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
-      - bluebird
       - bufferutil
       - encoding
       - eslint
       - supports-color
       - utf-8-validate
       - vue-template-compiler
-      - webpack-cli
-      - webpack-command
 
   /@storybook/csf-tools/6.5.6:
     resolution: {integrity: sha512-Gfah+5mEUoVG7v+E23svRjKAh546KCPIcwAvGU3m26j3hNbpvKq8edKDr+CCMfehG8VEGSZWfZPsgX04c/ItcA==}
@@ -6161,7 +5961,7 @@ packages:
       - react-dom
       - supports-color
 
-  /@storybook/manager-webpack4/6.5.6_6cc04611407a90b373e458ffdd9c2500:
+  /@storybook/manager-webpack4/6.5.6_1596ec9896079968c237ec0328822914:
     resolution: {integrity: sha512-GaUT1bNmGebq8Ci52M07XF0Zn9Ak7L8ZaKn8rdBJ4VSPhg0vEAeo7trD3aur3+h/3gLQmK64LhiNSOfvZfQDAw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -6176,7 +5976,7 @@ packages:
       '@babel/preset-react': 7.17.12_@babel+core@7.18.2
       '@storybook/addons': 6.5.6_react-dom@16.14.0+react@16.14.0
       '@storybook/core-client': 6.5.6_dde788d947c79adfe193fcb1e6bf6ea4
-      '@storybook/core-common': 6.5.6_6cc04611407a90b373e458ffdd9c2500
+      '@storybook/core-common': 6.5.6_1596ec9896079968c237ec0328822914
       '@storybook/node-logger': 6.5.6
       '@storybook/theming': 6.5.6_react-dom@16.14.0+react@16.14.0
       '@storybook/ui': 6.5.6_react-dom@16.14.0+react@16.14.0
@@ -6206,17 +6006,14 @@ packages:
       typescript: 4.6.4
       url-loader: 4.1.1_file-loader@6.2.0+webpack@4.43.0
       util-deprecate: 1.0.2
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
       webpack-dev-middleware: 3.7.3_webpack@4.43.0
       webpack-virtual-modules: 0.2.2
     transitivePeerDependencies:
-      - bluebird
       - encoding
       - eslint
       - supports-color
       - vue-template-compiler
-      - webpack-cli
-      - webpack-command
 
   /@storybook/manager-webpack5/6.5.6_6cc04611407a90b373e458ffdd9c2500:
     resolution: {integrity: sha512-U5OIMs1PNjZZRjOvV2Bo05+1dzvV30o4Lw5sgeyH9Qr08p79nHT4iFSaVF2W01zGja6XlneqFB9hBqBHoocJWQ==}
@@ -6233,7 +6030,7 @@ packages:
       '@babel/preset-react': 7.17.12_@babel+core@7.18.2
       '@storybook/addons': 6.5.6_react-dom@16.14.0+react@16.14.0
       '@storybook/core-client': 6.5.6_70e0e84c90518b506645de5b6d5501c2
-      '@storybook/core-common': 6.5.6_6cc04611407a90b373e458ffdd9c2500
+      '@storybook/core-common': 6.5.6_1596ec9896079968c237ec0328822914
       '@storybook/node-logger': 6.5.6
       '@storybook/theming': 6.5.6_react-dom@16.14.0+react@16.14.0
       '@storybook/ui': 6.5.6_react-dom@16.14.0+react@16.14.0
@@ -6272,7 +6069,7 @@ packages:
       - uglify-js
       - vue-template-compiler
       - webpack-cli
-      - webpack-command
+    dev: true
 
   /@storybook/mdx1-csf/0.0.1_@babel+core@7.18.2:
     resolution: {integrity: sha512-4biZIWWzoWlCarMZmTpqcJNgo/RBesYZwGFbQeXiGYsswuvfWARZnW9RE9aUEMZ4XPn7B1N3EKkWcdcWe/K2tg==}
@@ -6404,8 +6201,8 @@ packages:
       '@storybook/addons': 6.5.6_react-dom@16.14.0+react@16.14.0
       '@storybook/builder-webpack5': 6.5.6_6cc04611407a90b373e458ffdd9c2500
       '@storybook/client-logger': 6.5.6
-      '@storybook/core': 6.5.6_f05ea00584b166a2fb5b13fa151cfab0
-      '@storybook/core-common': 6.5.6_6cc04611407a90b373e458ffdd9c2500
+      '@storybook/core': 6.5.6_d9b4b98ca8479c4866a60963afdf1772
+      '@storybook/core-common': 6.5.6_1596ec9896079968c237ec0328822914
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.6_react-dom@16.14.0+react@16.14.0
       '@storybook/manager-webpack5': 6.5.6_6cc04611407a90b373e458ffdd9c2500
@@ -6442,7 +6239,6 @@ packages:
       - '@storybook/mdx2-csf'
       - '@swc/core'
       - '@types/webpack'
-      - bluebird
       - bufferutil
       - encoding
       - esbuild
@@ -6454,7 +6250,6 @@ packages:
       - utf-8-validate
       - vue-template-compiler
       - webpack-cli
-      - webpack-command
       - webpack-dev-server
       - webpack-hot-middleware
       - webpack-plugin-serve
@@ -6523,11 +6318,11 @@ packages:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  /@storybook/telemetry/6.5.6_6cc04611407a90b373e458ffdd9c2500:
+  /@storybook/telemetry/6.5.6_1596ec9896079968c237ec0328822914:
     resolution: {integrity: sha512-l0vbStCgVA9u0ITvowZ1LNxmf32vAAdnPqSmB9DdA3ZO2wCpttW9rPyg1O4OV8c5uq7QJZ7mrKZ04p9SLo8wrw==}
     dependencies:
       '@storybook/client-logger': 6.5.6
-      '@storybook/core-common': 6.5.6_6cc04611407a90b373e458ffdd9c2500
+      '@storybook/core-common': 6.5.6_1596ec9896079968c237ec0328822914
       chalk: 4.1.2
       core-js: 3.21.1
       detect-package-manager: 2.0.1
@@ -6546,8 +6341,6 @@ packages:
       - supports-color
       - typescript
       - vue-template-compiler
-      - webpack-cli
-      - webpack-command
 
   /@storybook/theming/6.5.6_react-dom@16.14.0+react@16.14.0:
     resolution: {integrity: sha512-JEKl9gdVD2Ef9xSwRtaq6EpjJD5xe7X2OP/4e61ucrp/rSOk7SOpYUZYQh6PhYLGhnGbgQkedVVc9CUhK8bs6Q==}
@@ -6805,6 +6598,10 @@ packages:
       '@types/node': 17.0.21
     dev: true
 
+  /@types/cookie/0.5.1:
+    resolution: {integrity: sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==}
+    dev: true
+
   /@types/cookies/0.7.5:
     resolution: {integrity: sha512-3+TAFSm78O7/bAeYdB8FoYGntuT87vVP9JKuQRL8sRhv9313LP2SpHHL50VeFtnyjIcb3UELddMk5Yt0eOSOkg==}
     dependencies:
@@ -6812,6 +6609,10 @@ packages:
       '@types/express': 4.17.9
       '@types/keygrip': 1.0.2
       '@types/node': 17.0.21
+    dev: true
+
+  /@types/cryptr/4.0.1:
+    resolution: {integrity: sha512-Nn8fvr+8XYWK5h422lj4xQACfOg6vdhKI+Rh9ERa5Mg0cZvPL9Vn3845vSY07dNZnEs5cqkSNVMdhmf70lAYkA==}
     dev: true
 
   /@types/enzyme/3.10.12:
@@ -6898,6 +6699,7 @@ packages:
 
   /@types/html-minifier-terser/6.1.0:
     resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}
+    dev: true
 
   /@types/http-cache-semantics/4.0.1:
     resolution: {integrity: sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==}
@@ -7468,6 +7270,7 @@ packages:
     dependencies:
       webpack: 5.73.0_webpack-cli@4.9.2
       webpack-cli: 4.9.2_webpack@5.73.0
+    dev: true
 
   /@webpack-cli/info/1.4.1_webpack-cli@4.9.2:
     resolution: {integrity: sha512-PKVGmazEq3oAo46Q63tpMr4HipI3OPfP7LiNOEJg963RMgT0rqheag28NCML0o3GIzA3DmxP1ZIAv9oTX1CUIA==}
@@ -7476,6 +7279,7 @@ packages:
     dependencies:
       envinfo: 7.8.1
       webpack-cli: 4.9.2_webpack@5.73.0
+    dev: true
 
   /@webpack-cli/serve/1.6.1_webpack-cli@4.9.2:
     resolution: {integrity: sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==}
@@ -7487,6 +7291,7 @@ packages:
         optional: true
     dependencies:
       webpack-cli: 4.9.2_webpack@5.73.0
+    dev: true
 
   /@wry/context/0.6.1:
     resolution: {integrity: sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==}
@@ -7779,8 +7584,6 @@ packages:
     dependencies:
       micromatch: 3.1.10
       normalize-path: 2.1.1
-    transitivePeerDependencies:
-      - supports-color
 
   /anymatch/3.1.2:
     resolution: {integrity: sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==}
@@ -8134,8 +7937,6 @@ packages:
       babel-template: 6.26.0
       babel-traverse: 6.26.0
       babel-types: 6.26.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /babel-helper-get-function-arity/6.24.1:
@@ -8143,24 +7944,6 @@ packages:
     dependencies:
       babel-runtime: 6.26.0
       babel-types: 6.26.0
-    dev: true
-
-  /babel-jest/28.1.0_@babel+core@7.18.0:
-    resolution: {integrity: sha512-zNKk0yhDZ6QUwfxh9k07GII6siNGMJWVUU49gmFj5gfdqDKLqa2RArXOF2CODp4Dr7dLxN2cvAV+667dGJ4b4w==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    peerDependencies:
-      '@babel/core': ^7.8.0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@jest/transform': 28.1.0
-      '@types/babel__core': 7.1.15
-      babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 28.0.2_@babel+core@7.18.0
-      chalk: 4.1.2
-      graceful-fs: 4.2.10
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /babel-jest/28.1.0_@babel+core@7.18.2:
@@ -8209,7 +7992,7 @@ packages:
       loader-utils: 1.4.0
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
 
   /babel-loader/8.2.3_1e6208c184491b2ebbab8f4236ed439d:
     resolution: {integrity: sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==}
@@ -8224,6 +8007,7 @@ packages:
       make-dir: 3.1.0
       schema-utils: 2.7.1
       webpack: 5.73.0_webpack-cli@4.9.2
+    dev: true
 
   /babel-messages/6.23.0:
     resolution: {integrity: sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=}
@@ -8302,6 +8086,7 @@ packages:
 
   /babel-plugin-named-exports-order/0.0.2:
     resolution: {integrity: sha512-OgOYHOLoRK+/mvXU9imKHlG6GkPLYrUCvFXG/CM93R/aNNO8pOOF4aS+S8CCHMDQoNSeiOYEZb/G6RwL95Jktw==}
+    dev: true
 
   /babel-plugin-polyfill-corejs2/0.3.1_@babel+core@7.18.2:
     resolution: {integrity: sha512-v7/T6EQcNfVLfcN2X8Lulb7DjprieyLWJK/zOWH5DUYcAgex9sP3h25Q+DLsX9TloXe3y1O8l2q2Jv9q8UVB9w==}
@@ -8367,28 +8152,6 @@ packages:
       babel-plugin-syntax-class-properties: 6.13.0
       babel-runtime: 6.26.0
       babel-template: 6.26.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /babel-preset-current-node-syntax/1.0.1_@babel+core@7.18.0:
-    resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.18.0
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.18.0
-      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.18.0
-      '@babel/plugin-syntax-class-properties': 7.12.13_@babel+core@7.18.0
-      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.18.0
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.18.0
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.18.0
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.18.0
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.18.0
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.18.0
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.18.0
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.18.0
-      '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.18.0
     dev: true
 
   /babel-preset-current-node-syntax/1.0.1_@babel+core@7.18.2:
@@ -8409,17 +8172,6 @@ packages:
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.18.2
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.18.2
       '@babel/plugin-syntax-top-level-await': 7.14.5_@babel+core@7.18.2
-    dev: true
-
-  /babel-preset-jest/28.0.2_@babel+core@7.18.0:
-    resolution: {integrity: sha512-sYzXIdgIXXroJTFeB3S6sNDWtlJ2dllCdTEsnZ65ACrMojj3hVNFRmnJ1HZtomGi+Be7aqpY/HJ92fr8OhKVkQ==}
-    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.18.0
-      babel-plugin-jest-hoist: 28.0.2
-      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.18.0
     dev: true
 
   /babel-preset-jest/28.0.2_@babel+core@7.18.2:
@@ -8448,8 +8200,6 @@ packages:
       babel-types: 6.26.0
       babylon: 6.18.0
       lodash: 4.17.21
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /babel-traverse/6.26.0:
@@ -8464,8 +8214,6 @@ packages:
       globals: 9.18.0
       invariant: 2.2.4
       lodash: 4.17.21
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /babel-types/6.26.0:
@@ -8597,8 +8345,6 @@ packages:
       qs: 6.9.7
       raw-body: 2.4.3
       type-is: 1.6.18
-    transitivePeerDependencies:
-      - supports-color
 
   /boolbase/1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -8642,8 +8388,6 @@ packages:
       snapdragon-node: 2.1.1
       split-string: 3.1.0
       to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   /braces/3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -8656,6 +8400,7 @@ packages:
 
   /browser-assert/1.2.1:
     resolution: {integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==}
+    dev: true
 
   /browser-process-hrtime/1.0.0:
     resolution: {integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==}
@@ -8861,7 +8606,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.5
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1_bluebird@3.7.2
+      promise-inflight: 1.0.1
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -8889,8 +8634,6 @@ packages:
       ssri: 8.0.1
       tar: 6.1.11
       unique-filename: 1.1.1
-    transitivePeerDependencies:
-      - bluebird
 
   /cache-base/1.0.1:
     resolution: {integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==}
@@ -9121,8 +8864,6 @@ packages:
       upath: 1.2.0
     optionalDependencies:
       fsevents: 1.2.13
-    transitivePeerDependencies:
-      - supports-color
     optional: true
 
   /chokidar/3.5.3:
@@ -9283,13 +9024,6 @@ packages:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
     engines: {node: '>= 10'}
 
-  /client-sessions/0.8.0:
-    resolution: {integrity: sha1-p9jFVYrV1W8qGZ81M+tlS134k/0=}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      cookies: 0.7.3
-    dev: false
-
   /clipboard/2.0.11:
     resolution: {integrity: sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==}
     requiresBuild: true
@@ -9326,7 +9060,7 @@ packages:
     engines: {node: '>=0.8'}
 
   /co/4.6.0:
-    resolution: {integrity: sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=}
+    resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
     dev: true
 
@@ -9368,9 +9102,11 @@ packages:
 
   /colorette/1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
+    dev: true
 
   /colorette/2.0.16:
     resolution: {integrity: sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==}
+    dev: true
 
   /colors/1.4.0:
     resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
@@ -9452,8 +9188,6 @@ packages:
       on-headers: 1.0.2
       safe-buffer: 5.1.2
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
 
   /concat-map/0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -9518,17 +9252,14 @@ packages:
     resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
     engines: {node: '>= 0.6'}
 
+  /cookie/0.5.0:
+    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /cookiejar/2.1.3:
     resolution: {integrity: sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==}
     dev: true
-
-  /cookies/0.7.3:
-    resolution: {integrity: sha512-+gixgxYSgQLTaTIilDHAdlNPZDENDQernEMiIcZpYYP14zgHsCt4Ce1FEjFtcp6GefhozebB6orvhAAWx/IS0A==}
-    engines: {node: '>= 0.8'}
-    dependencies:
-      depd: 1.1.2
-      keygrip: 1.0.3
-    dev: false
 
   /copy-concurrently/1.0.5:
     resolution: {integrity: sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==}
@@ -9620,8 +9351,6 @@ packages:
       p-all: 2.1.0
       p-filter: 2.1.0
       p-map: 3.0.0
-    transitivePeerDependencies:
-      - supports-color
 
   /crc-32/1.2.1:
     resolution: {integrity: sha512-Dn/xm/1vFFgs3nfrpEVScHoIslO9NZRITWGz/1E/St6u4xw99vfZzVkW0OSnzx2h9egej9xwMCEut6sqwokM/w==}
@@ -9699,6 +9428,10 @@ packages:
       randombytes: 2.1.0
       randomfill: 1.0.4
 
+  /cryptr/6.0.3:
+    resolution: {integrity: sha512-Nhaxn3CYl/OoWF3JSZlF8B6FQO600RRkU3g8213OGEIq4YvMlc3od8hL9chubhY1SmTq8ienvCRq1MSFjMTpOg==}
+    dev: false
+
   /css-loader/3.6.0_webpack@4.43.0:
     resolution: {integrity: sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==}
     engines: {node: '>= 8.9.0'}
@@ -9718,7 +9451,7 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 2.7.1
       semver: 6.3.0
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
 
   /css-loader/5.2.7_webpack@5.73.0:
     resolution: {integrity: sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==}
@@ -9737,6 +9470,7 @@ packages:
       schema-utils: 3.1.1
       semver: 7.3.7
       webpack: 5.73.0_webpack-cli@4.9.2
+    dev: true
 
   /css-loader/6.7.1_webpack@5.73.0:
     resolution: {integrity: sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==}
@@ -9841,7 +9575,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@cypress/request': 2.88.10
-      '@cypress/xvfb': 1.2.4_supports-color@8.1.1
+      '@cypress/xvfb': 1.2.4
       '@types/node': 14.14.33
       '@types/sinonjs__fake-timers': 8.1.1
       '@types/sizzle': 2.3.3
@@ -9912,43 +9646,16 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.0.0
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.1.3
-
-  /debug/3.2.7_supports-color@8.1.1:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.1.3
-      supports-color: 8.1.1
-    dev: true
 
   /debug/4.1.1:
     resolution: {integrity: sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
     dependencies:
       ms: 2.1.3
     dev: false
@@ -9975,6 +9682,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+    dev: false
 
   /debug/4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -10237,8 +9945,6 @@ packages:
     dependencies:
       address: 1.1.2
       debug: 2.6.9
-    transitivePeerDependencies:
-      - supports-color
 
   /diff-sequences/27.5.1:
     resolution: {integrity: sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==}
@@ -10513,6 +10219,7 @@ packages:
     resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
 
   /enzyme-adapter-react-16/1.15.6_4f82faf5e8cab057bc46d4d95079ec42:
     resolution: {integrity: sha512-yFlVJCXh8T+mcQo8M6my9sPgeGzj85HSHi6Apgf1Cvq/7EL/J9+1JoJmJsRxZgyTvPMAqOEpRSu/Ii/ZpyOk0g==}
@@ -11191,7 +10898,7 @@ packages:
     dev: true
 
   /exit/0.1.2:
-    resolution: {integrity: sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=}
+    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
     dev: true
 
@@ -11206,8 +10913,6 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   /expand-tilde/2.0.2:
     resolution: {integrity: sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=}
@@ -11260,8 +10965,6 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
 
   /ext-list/2.2.2:
     resolution: {integrity: sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==}
@@ -11320,8 +11023,6 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   /extract-zip/2.0.1_supports-color@8.1.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -11362,8 +11063,6 @@ packages:
       is-glob: 4.0.3
       merge2: 1.4.1
       micromatch: 3.1.10
-    transitivePeerDependencies:
-      - supports-color
 
   /fast-glob/3.2.11:
     resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==}
@@ -11386,6 +11085,7 @@ packages:
 
   /fastest-levenshtein/1.0.12:
     resolution: {integrity: sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==}
+    dev: true
 
   /fastq/1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
@@ -11429,7 +11129,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
 
   /file-system-cache/1.0.5:
     resolution: {integrity: sha512-w9jqeQdOeVaXBCgl4c90XJ6zI8MguJgSiC5LsLdhUu6eSCzcRHPPXUF3lkKMagpzHi+6GnDkjv9BtxMmXdvptA==}
@@ -11518,8 +11218,6 @@ packages:
       parseurl: 1.3.3
       statuses: 1.5.0
       unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
 
   /find-cache-dir/2.1.0:
     resolution: {integrity: sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==}
@@ -11634,6 +11332,7 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: true
 
   /follow-redirects/1.14.9_debug@4.3.2:
     resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}
@@ -11645,7 +11344,6 @@ packages:
         optional: true
     dependencies:
       debug: 4.3.2
-    dev: true
 
   /for-in/1.0.2:
     resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}
@@ -11668,19 +11366,9 @@ packages:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
     dev: true
 
-  /fork-ts-checker-webpack-plugin/4.1.6_typescript@4.6.4+webpack@4.43.0:
+  /fork-ts-checker-webpack-plugin/4.1.6:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
-    peerDependencies:
-      eslint: '>= 6'
-      typescript: '>= 2.7'
-      vue-template-compiler: '*'
-      webpack: '>= 4'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-      vue-template-compiler:
-        optional: true
     dependencies:
       '@babel/code-frame': 7.16.7
       chalk: 2.4.2
@@ -11688,11 +11376,7 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.1
       tapable: 1.1.3
-      typescript: 4.6.4
-      webpack: 4.43.0_webpack-cli@4.9.2
       worker-rpc: 0.1.1
-    transitivePeerDependencies:
-      - supports-color
 
   /fork-ts-checker-webpack-plugin/6.5.0_typescript@4.6.4+webpack@4.43.0:
     resolution: {integrity: sha512-cS178Y+xxtIjEUorcHddKS7yCMlrDPV31mt47blKKRfMd70Kxu5xruAFE2o9sDY6wVC5deuob/u/alD04YYHnw==}
@@ -11722,7 +11406,7 @@ packages:
       semver: 7.3.7
       tapable: 1.1.3
       typescript: 4.6.4
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
 
   /fork-ts-checker-webpack-plugin/6.5.0_typescript@4.6.4+webpack@5.73.0:
     resolution: {integrity: sha512-cS178Y+xxtIjEUorcHddKS7yCMlrDPV31mt47blKKRfMd70Kxu5xruAFE2o9sDY6wVC5deuob/u/alD04YYHnw==}
@@ -11753,6 +11437,7 @@ packages:
       tapable: 1.1.3
       typescript: 4.6.4
       webpack: 5.73.0_webpack-cli@4.9.2
+    dev: true
 
   /fork-ts-checker-webpack-plugin/7.2.11_typescript@4.6.4+webpack@5.73.0:
     resolution: {integrity: sha512-2e5+NyTUTE1Xq4fWo7KFEQblCaIvvINQwUX3jRmEGlgCTc1Ecqw/975EfQrQ0GEraxJTnp8KB9d/c8hlCHUMJA==}
@@ -12221,8 +11906,6 @@ packages:
       ignore: 4.0.6
       pify: 4.0.1
       slash: 2.0.0
-    transitivePeerDependencies:
-      - supports-color
 
   /good-listener/1.2.2:
     resolution: {integrity: sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=}
@@ -12298,6 +11981,7 @@ packages:
   /graphql/15.8.0:
     resolution: {integrity: sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==}
     engines: {node: '>= 10.x'}
+    dev: true
 
   /gzip-size/6.0.0:
     resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
@@ -12635,7 +12319,7 @@ packages:
       pretty-error: 2.1.2
       tapable: 1.1.3
       util.promisify: 1.0.0
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
 
   /html-webpack-plugin/5.5.0_webpack@5.73.0:
     resolution: {integrity: sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==}
@@ -12649,6 +12333,7 @@ packages:
       pretty-error: 4.0.0
       tapable: 2.2.1
       webpack: 5.73.0_webpack-cli@4.9.2
+    dev: true
 
   /htmlparser2/3.10.1:
     resolution: {integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==}
@@ -12702,7 +12387,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.3
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12730,7 +12415,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.5
-      follow-redirects: 1.14.9
+      follow-redirects: 1.14.9_debug@4.3.2
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -12854,6 +12539,7 @@ packages:
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
+    dev: true
 
   /imurmurhash/0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -13390,6 +13076,7 @@ packages:
 
   /isarray/0.0.1:
     resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
+    dev: true
 
   /isarray/1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -13468,7 +13155,7 @@ packages:
     resolution: {integrity: sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==}
     engines: {node: '>=8'}
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -13566,10 +13253,10 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.18.0
+      '@babel/core': 7.18.2
       '@jest/test-sequencer': 28.1.0
       '@jest/types': 28.1.0
-      babel-jest: 28.1.0_@babel+core@7.18.0
+      babel-jest: 28.1.0_@babel+core@7.18.2
       chalk: 4.1.2
       ci-info: 3.3.1
       deepmerge: 4.2.2
@@ -13604,11 +13291,11 @@ packages:
       ts-node:
         optional: true
     dependencies:
-      '@babel/core': 7.18.0
+      '@babel/core': 7.18.2
       '@jest/test-sequencer': 28.1.0
       '@jest/types': 28.1.0
       '@types/node': 17.0.21
-      babel-jest: 28.1.0_@babel+core@7.18.0
+      babel-jest: 28.1.0_@babel+core@7.18.2
       chalk: 4.1.2
       ci-info: 3.3.1
       deepmerge: 4.2.2
@@ -13729,8 +13416,6 @@ packages:
       walker: 1.0.7
     optionalDependencies:
       fsevents: 2.3.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /jest-haste-map/28.1.0:
@@ -13921,17 +13606,17 @@ packages:
     resolution: {integrity: sha512-ex49M2ZrZsUyQLpLGxQtDbahvgBjlLPgklkqGM0hq/F7W/f8DyqZxVHjdy19QKBm4O93eDp+H5S23EiTbbUmHw==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
-      '@babel/core': 7.18.0
-      '@babel/generator': 7.18.0
-      '@babel/plugin-syntax-typescript': 7.17.12_@babel+core@7.18.0
-      '@babel/traverse': 7.17.12
-      '@babel/types': 7.18.0
+      '@babel/core': 7.18.2
+      '@babel/generator': 7.18.2
+      '@babel/plugin-syntax-typescript': 7.17.12_@babel+core@7.18.2
+      '@babel/traverse': 7.18.2
+      '@babel/types': 7.18.2
       '@jest/expect-utils': 28.1.0
       '@jest/transform': 28.1.0
       '@jest/types': 28.1.0
       '@types/babel__traverse': 7.14.2
       '@types/prettier': 2.3.2
-      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.18.0
+      babel-preset-current-node-syntax: 1.0.1_@babel+core@7.18.2
       chalk: 4.1.2
       expect: 28.1.0
       graceful-fs: 4.2.10
@@ -14167,7 +13852,7 @@ packages:
   /json-parse-even-better-errors/2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
-  /json-refs/3.0.15_supports-color@8.1.1:
+  /json-refs/3.0.15:
     resolution: {integrity: sha512-0vOQd9eLNBL18EGl5yYaO44GhixmImes2wiYn9Z3sag3QnehWrYWlB9AFtMxCL2Bj3fyxgDYkxGFEU/chlYssw==}
     engines: {node: '>=0.8'}
     hasBin: true
@@ -14177,11 +13862,9 @@ packages:
       js-yaml: 3.14.1
       lodash: 4.17.21
       native-promise-only: 0.8.1
-      path-loader: 1.0.10_supports-color@8.1.1
+      path-loader: 1.0.10
       slash: 3.0.0
       uri-js: 4.4.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /json-schema-traverse/0.4.1:
@@ -14257,11 +13940,6 @@ packages:
   /jwt-decode/3.1.2:
     resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
     dev: true
-
-  /keygrip/1.0.3:
-    resolution: {integrity: sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g==}
-    engines: {node: '>= 0.6'}
-    dev: false
 
   /keyv/4.1.1:
     resolution: {integrity: sha512-tGv1yP6snQVDSM4X6yxrv2zzq/EvpW+oYiUz6aueW1u9CtS8RzUQYxxmFwgZlO2jSgCxQbchhxaqXXp2hnKGpQ==}
@@ -14654,6 +14332,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       p-defer: 1.0.0
+    dev: true
 
   /map-cache/0.2.2:
     resolution: {integrity: sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==}
@@ -14749,6 +14428,7 @@ packages:
     dependencies:
       map-age-cleaner: 0.1.3
       mimic-fn: 3.1.0
+    dev: true
 
   /memfs/3.4.1:
     resolution: {integrity: sha512-1c9VPVvW5P7I85c35zAdEr1TD5+F11IToIHIlrVIcflfnzPkJa0ZoYEoEdYDP8KgPFoSZ/opDrUsAoZWym3mtw==}
@@ -14844,8 +14524,6 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   /micromatch/4.0.4:
     resolution: {integrity: sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==}
@@ -14901,6 +14579,7 @@ packages:
   /mimic-fn/3.1.0:
     resolution: {integrity: sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==}
     engines: {node: '>=8'}
+    dev: true
 
   /mimic-response/1.0.1:
     resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
@@ -14931,6 +14610,7 @@ packages:
       prop-types: 15.8.1
       react: 16.14.0
       tiny-warning: 1.0.3
+    dev: true
 
   /mini-css-extract-plugin/2.6.0_webpack@5.73.0:
     resolution: {integrity: sha512-ndG8nxCEnAemsg4FSgS+yNyHKgkTB4nPKqCOgh65j3/30qqC5RaSQQXMm++Y6sb6E1zRSxPkztj9fqxhS1Eo6w==}
@@ -15103,15 +14783,13 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   /native-promise-only/0.8.1:
     resolution: {integrity: sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg==}
     dev: true
 
   /natural-compare/1.4.0:
-    resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
   /ncjsm/4.3.0:
@@ -15636,6 +15314,7 @@ packages:
   /p-defer/1.0.0:
     resolution: {integrity: sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==}
     engines: {node: '>=4'}
+    dev: true
 
   /p-event/4.2.0:
     resolution: {integrity: sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==}
@@ -15827,6 +15506,7 @@ packages:
 
   /path-browserify/1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+    dev: true
 
   /path-case/3.0.4:
     resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
@@ -15870,13 +15550,11 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  /path-loader/1.0.10_supports-color@8.1.1:
+  /path-loader/1.0.10:
     resolution: {integrity: sha512-CMP0v6S6z8PHeJ6NFVyVJm6WyJjIwFvyz2b0n2/4bKdS/0uZa/9sKUlYZzubrn3zuDRU0zIuEDX9DZYQ2ZI8TA==}
     dependencies:
       native-promise-only: 0.8.1
-      superagent: 3.8.3_supports-color@8.1.1
-    transitivePeerDependencies:
-      - supports-color
+      superagent: 3.8.3
     dev: true
 
   /path-parse/1.0.6:
@@ -15903,6 +15581,7 @@ packages:
     resolution: {integrity: sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==}
     dependencies:
       isarray: 0.0.1
+    dev: true
 
   /path-type/1.1.0:
     resolution: {integrity: sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==}
@@ -16071,7 +15750,7 @@ packages:
       postcss: 7.0.39
       schema-utils: 3.1.1
       semver: 7.3.7
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
 
   /postcss-modules-extract-imports/2.0.0:
     resolution: {integrity: sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==}
@@ -16194,6 +15873,7 @@ packages:
     dependencies:
       lodash: 4.17.21
       renderkid: 3.0.0
+    dev: true
 
   /pretty-format/27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -16258,21 +15938,6 @@ packages:
 
   /promise-inflight/1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
-
-  /promise-inflight/1.0.1_bluebird@3.7.2:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
-    dependencies:
-      bluebird: 3.7.2
 
   /promise-queue/2.2.5:
     resolution: {integrity: sha512-p/iXrPSVfnqPft24ZdNNLECw/UrtLTpT3jpAAMzl/o5/rDsGCPo3/CQS2611flL6LkoEJ3oQZw7C8Q80ZISXRQ==}
@@ -16508,7 +16173,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
 
   /react-docgen-typescript/2.2.2_typescript@4.6.4:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
@@ -16545,6 +16210,7 @@ packages:
       prop-types: 15.8.1
       react: 16.14.0
       scheduler: 0.19.1
+    dev: true
 
   /react-element-to-jsx-string/14.3.4_react-dom@16.14.0+react@16.14.0:
     resolution: {integrity: sha512-t4ZwvV6vwNxzujDQ+37bspnLwA4JlgUPWhLjBJWsNIDceAf6ZKUTCjdm08cN6WeZ5pTMKiCJkmAYnpmR4Bm+dg==}
@@ -16619,6 +16285,7 @@ packages:
       react-router: 5.3.3_react@16.14.0
       tiny-invariant: 1.2.0
       tiny-warning: 1.0.3
+    dev: true
 
   /react-router-hash-link/2.4.3_a451da5b949fedfa55800d6967ec9ba8:
     resolution: {integrity: sha512-NU7GWc265m92xh/aYD79Vr1W+zAIXDWp3L2YZOYP4rCqPnJ6LI6vh3+rKgkidtYijozHclaEQTAHaAaMWPVI4A==}
@@ -16647,6 +16314,7 @@ packages:
       react-is: 16.13.1
       tiny-invariant: 1.2.0
       tiny-warning: 1.0.3
+    dev: true
 
   /react-sizeme/3.0.2:
     resolution: {integrity: sha512-xOIAOqqSSmKlKFJLO3inBQBdymzDuXx4iuwkNcJmC96jeiOg5ojByvL+g3MW9LPEsojLbC6pf68zOfobK8IPlw==}
@@ -16688,6 +16356,7 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.8.1
+    dev: true
 
   /read-pkg-up/1.0.1:
     resolution: {integrity: sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=}
@@ -16763,8 +16432,6 @@ packages:
       graceful-fs: 4.2.10
       micromatch: 3.1.10
       readable-stream: 2.3.7
-    transitivePeerDependencies:
-      - supports-color
     optional: true
 
   /readdirp/3.6.0:
@@ -16785,6 +16452,7 @@ packages:
     engines: {node: '>= 0.10'}
     dependencies:
       resolve: 1.22.0
+    dev: true
 
   /rechoir/0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
@@ -17035,6 +16703,7 @@ packages:
       htmlparser2: 6.1.0
       lodash: 4.17.21
       strip-ansi: 6.0.1
+    dev: true
 
   /repeat-element/1.1.4:
     resolution: {integrity: sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==}
@@ -17084,6 +16753,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       resolve-from: 5.0.0
+    dev: true
 
   /resolve-dir/1.0.1:
     resolution: {integrity: sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=}
@@ -17330,8 +17000,6 @@ packages:
       micromatch: 3.1.10
       minimist: 1.2.6
       walker: 1.0.7
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /sass-loader/13.0.0_sass@1.52.1+webpack@5.73.0:
@@ -17396,6 +17064,7 @@ packages:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
+    dev: true
 
   /schema-utils/1.0.0:
     resolution: {integrity: sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==}
@@ -17502,8 +17171,6 @@ packages:
       on-finished: 2.3.0
       range-parser: 1.2.1
       statuses: 1.4.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /send/0.17.2:
@@ -17523,8 +17190,6 @@ packages:
       on-finished: 2.3.0
       range-parser: 1.2.1
       statuses: 1.5.0
-    transitivePeerDependencies:
-      - supports-color
 
   /sentence-case/3.0.4:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
@@ -17566,8 +17231,6 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.17.2
-    transitivePeerDependencies:
-      - supports-color
 
   /serverless-http/3.0.1:
     resolution: {integrity: sha512-VEgmMYXvlZ5PLkBAj2IIAGIw25RBsDnLu2fansuaFCmw2fXGUP1VGROfTaEJrjHpZrmvlPu1JRFDNRV8UvDFyw==}
@@ -17611,7 +17274,7 @@ packages:
       is-docker: 2.2.1
       js-yaml: 4.1.0
       json-cycle: 1.3.0
-      json-refs: 3.0.15_supports-color@8.1.1
+      json-refs: 3.0.15
       lodash: 4.17.21
       memoizee: 0.4.15
       micromatch: 4.0.5
@@ -17817,8 +17480,6 @@ packages:
       source-map: 0.5.7
       source-map-resolve: 0.5.3
       use: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
 
   /sort-keys-length/1.0.1:
     resolution: {integrity: sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=}
@@ -18289,7 +17950,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 2.7.1
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
 
   /style-loader/2.0.0_webpack@5.73.0:
     resolution: {integrity: sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==}
@@ -18300,20 +17961,21 @@ packages:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
       webpack: 5.73.0_webpack-cli@4.9.2
+    dev: true
 
   /style-to-object/0.3.0:
     resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}
     dependencies:
       inline-style-parser: 0.1.1
 
-  /superagent/3.8.3_supports-color@8.1.1:
+  /superagent/3.8.3:
     resolution: {integrity: sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==}
     engines: {node: '>= 4.0'}
     deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
     dependencies:
       component-emitter: 1.3.0
       cookiejar: 2.1.3
-      debug: 3.2.7_supports-color@8.1.1
+      debug: 3.2.7
       extend: 3.0.2
       form-data: 2.5.1
       formidable: 1.2.6
@@ -18321,8 +17983,6 @@ packages:
       mime: 1.6.0
       qs: 6.10.3
       readable-stream: 2.3.7
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /supports-color/2.0.0:
@@ -18464,7 +18124,7 @@ packages:
       serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.0
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
 
@@ -18482,10 +18142,8 @@ packages:
       serialize-javascript: 5.0.1
       source-map: 0.6.1
       terser: 5.12.1
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
       webpack-sources: 1.4.3
-    transitivePeerDependencies:
-      - bluebird
 
   /terser-webpack-plugin/5.3.1_webpack@5.70.0:
     resolution: {integrity: sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==}
@@ -18556,6 +18214,7 @@ packages:
       source-map: 0.6.1
       terser: 5.12.1
       webpack: 5.73.0_webpack-cli@4.9.2
+    dev: true
 
   /terser/4.8.0:
     resolution: {integrity: sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==}
@@ -18791,6 +18450,42 @@ packages:
       tslib: 2.4.0
     dev: true
 
+  /ts-jest/28.0.2_823136af10737b04809fd90c6c630aeb:
+    resolution: {integrity: sha512-IOZMb3D0gx6IHO9ywPgiQxJ3Zl4ECylEFwoVpENB55aTn5sdO0Ptyx/7noNBxAaUff708RqQL4XBNxxOVjY0vQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@types/jest': ^27.0.0
+      babel-jest: ^28.0.0
+      esbuild: '*'
+      jest: ^28.0.0
+      typescript: '>=4.3'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@types/jest':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.18.2
+      '@types/jest': 27.5.2
+      babel-jest: 28.1.0_@babel+core@7.18.2
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      jest: 28.1.0
+      jest-util: 28.1.0
+      json5: 2.2.1
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.3.7
+      typescript: 4.6.4
+      yargs-parser: 20.2.9
+    dev: true
+
   /ts-jest/28.0.3_823136af10737b04809fd90c6c630aeb:
     resolution: {integrity: sha512-HzgbEDQ2KgVtDmpXToqAcKTyGHdHsG23i/iUjfxji92G5eT09S1m9UHZd7csF0Bfgh9txM4JzwHnv7r1waFPlw==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -18915,6 +18610,7 @@ packages:
     resolution: {integrity: sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: true
 
   /uglify-js/3.15.5:
     resolution: {integrity: sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==}
@@ -19158,7 +18854,7 @@ packages:
       loader-utils: 2.0.2
       mime-types: 2.1.35
       schema-utils: 3.1.1
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
 
   /url-parse/1.4.7:
     resolution: {integrity: sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==}
@@ -19367,8 +19063,6 @@ packages:
     requiresBuild: true
     dependencies:
       chokidar: 2.1.8
-    transitivePeerDependencies:
-      - supports-color
     optional: true
 
   /watchpack/1.7.5:
@@ -19379,8 +19073,6 @@ packages:
     optionalDependencies:
       chokidar: 3.5.3
       watchpack-chokidar2: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   /watchpack/2.3.1:
     resolution: {integrity: sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==}
@@ -19463,6 +19155,7 @@ packages:
       rechoir: 0.7.1
       webpack: 5.73.0_webpack-cli@4.9.2
       webpack-merge: 5.8.0
+    dev: true
 
   /webpack-dev-middleware/3.7.3_webpack@4.43.0:
     resolution: {integrity: sha512-djelc/zGiz9nZj/U7PTBi2ViorGJXEWo/3ltkPbDyxCXhhEXkW0ce99falaok4TPj+AsxLiXJR0EBOb0zh9fKQ==}
@@ -19474,7 +19167,7 @@ packages:
       mime: 2.6.0
       mkdirp: 0.5.5
       range-parser: 1.2.1
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
       webpack-log: 2.0.0
 
   /webpack-dev-middleware/4.3.0_webpack@5.73.0:
@@ -19490,6 +19183,7 @@ packages:
       range-parser: 1.2.1
       schema-utils: 3.1.1
       webpack: 5.73.0_webpack-cli@4.9.2
+    dev: true
 
   /webpack-dev-middleware/5.3.3_webpack@5.73.0:
     resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
@@ -19511,7 +19205,7 @@ packages:
     peerDependencies:
       webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
     dependencies:
-      webpack: 4.43.0_webpack-cli@4.9.2
+      webpack: 4.43.0
 
   /webpack-hot-middleware/2.25.1:
     resolution: {integrity: sha512-Koh0KyU/RPYwel/khxbsDz9ibDivmUbrRuKSSQvW42KSDdO4w23WI3SkHpSUKHE76LrFnnM/L7JCrpBwu8AXYw==}
@@ -19545,6 +19239,7 @@ packages:
     dependencies:
       clone-deep: 4.0.1
       wildcard: 2.0.0
+    dev: true
 
   /webpack-node-externals/3.0.0:
     resolution: {integrity: sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==}
@@ -19573,24 +19268,15 @@ packages:
     resolution: {integrity: sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==}
     dependencies:
       debug: 3.2.7
-    transitivePeerDependencies:
-      - supports-color
 
   /webpack-virtual-modules/0.4.3:
     resolution: {integrity: sha512-5NUqC2JquIL2pBAAo/VfBP6KuGkHIZQXW/lNKupLPfhViwh8wNsu0BObtl09yuKZszeEUfbXz8xhrHvSG16Nqw==}
+    dev: true
 
-  /webpack/4.43.0_webpack-cli@4.9.2:
+  /webpack/4.43.0:
     resolution: {integrity: sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==}
     engines: {node: '>=6.11.5'}
     hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-      webpack-command: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-      webpack-command:
-        optional: true
     dependencies:
       '@webassemblyjs/ast': 1.9.0
       '@webassemblyjs/helper-module-context': 1.9.0
@@ -19614,10 +19300,7 @@ packages:
       tapable: 1.1.3
       terser-webpack-plugin: 1.4.5_webpack@4.43.0
       watchpack: 1.7.5
-      webpack-cli: 4.9.2_webpack@5.73.0
       webpack-sources: 1.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   /webpack/5.70.0_webpack-cli@4.9.2:
     resolution: {integrity: sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==}
@@ -19739,6 +19422,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
 
   /whatwg-encoding/2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
@@ -19809,6 +19493,7 @@ packages:
 
   /wildcard/2.0.0:
     resolution: {integrity: sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==}
+    dev: true
 
   /word-wrap/1.2.3:
     resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}


### PR DESCRIPTION
Under European legislation (still valid in the UK) we should require users to opt-in to optional cookies before setting them on their device. This provides the underlying, server-side support for tracking which cookies they have consented to and will lay the groundwork for providing UI elements for this 'out of the box'.

**BREAKING:** The `auth.sessionSecret` config option has been replaced with
`cookies.secret`. Users will need to update their calling code to accommodate.