### PR TITLE
CI: Split up Main workflow

### DIFF
--- a/.github/actions/scan-code/action.yml
+++ b/.github/actions/scan-code/action.yml
@@ -4,10 +4,6 @@ inputs:
   token:
     description: GitHub token
     required: true
-  baseline-branch:
-    description: Name of branch to store baseline on
-    required: false
-    default: master
 runs:
   using: composite
   steps:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -1,10 +1,5 @@
-name: 'CodeQL'
+name: 'Analysis'
 on:
-  push:
-    branches: [ 'master' ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ 'master' ]
   schedule:
     - cron: '35 1 * * 2'
 jobs:
@@ -17,8 +12,6 @@ jobs:
       security-events: write
     strategy:
       fail-fast: false
-      matrix:
-        node: [ '16' ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -26,10 +19,9 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node: ${{ matrix.node }}
+          node: 16
 
       - name: Scan code-base
         uses: ./.github/actions/scan-code
         with:
-          baseline-branch: 'master'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/change-assurance.yml
+++ b/.github/workflows/change-assurance.yml
@@ -1,7 +1,6 @@
-name: Main
+name: Change assurance
 on:
-  - pull_request
-  - push
+  pull_request:
 jobs:
   common:
     name: Dependencies, Unit tests
@@ -21,17 +20,12 @@ jobs:
 
       - name: Run unit tests
         uses: ./.github/actions/test-code
-        with:
-          baseline-branch: 'master'
 
   libs:
     name: Build libraries
     needs:
       - common
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [ '16' ]
     steps:
 
       - name: Check out repository
@@ -40,43 +34,10 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node: ${{ matrix.node }}
+          node: 16
 
       - name: Build libraries
         run: npm run libs:build
-
-  chromatic:
-    name: Chromatic
-    needs:
-      - libs
-    runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
-    strategy:
-      matrix:
-        node: [ '16' ]
-    steps:
-
-      - name: Check out repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Setup
-        uses: ./.github/actions/setup
-        with:
-          node: ${{ matrix.node }}
-
-      - name: Push Storybook to Chromatic
-        env:
-          NODE_OPTIONS: --max_old_space_size=6144
-        uses: chromaui/action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          buildScriptName: 'build:storybook'
-          autoAcceptChanges: master
-          exitZeroOnChanges: true
-          exitOnceUploaded: true
 
   build-app:
     name: Build application
@@ -86,7 +47,6 @@ jobs:
     strategy:
       matrix:
         app: [ 'govuk-docs', 'govuk-template' ]
-        node: [ '16' ]
     steps:
 
       - name: Check out repository
@@ -95,7 +55,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node: ${{ matrix.node }}
+          node: 16
 
       - name: Build
         uses: ./.github/actions/build-app
@@ -119,7 +79,6 @@ jobs:
       matrix:
         app: [ 'govuk-docs', 'govuk-template' ]
         browser: [ 'chromium', 'firefox', 'electron' ]
-        node: [ '16' ]
     steps:
 
       - name: Check out repository
@@ -128,7 +87,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node: ${{ matrix.node }}
+          node: 16
 
       - name: Download build directory
         uses: actions/download-artifact@v3
@@ -144,19 +103,3 @@ jobs:
           cypress-project-id: ${{ secrets.CYPRESS_PROJECT_ID }}
           cypress-record-key: ${{ secrets.CYPRESS_RECORD_KEY }}
           node: ${{ matrix.node }}
-
-  deploy-docs-to-netlify:
-    name: Deploy to Netlify and test
-    if: github.event_name != 'pull_request'
-    needs:
-      - build-app
-    uses: './.github/workflows/deploy-to-netlify.yml'
-    with:
-      app: govuk-docs
-      node: 16
-      production-branch: master
-    secrets:
-      CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
-      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/deploy-to-heroku.yml
+++ b/.github/workflows/deploy-to-heroku.yml
@@ -21,8 +21,8 @@ on:
       HEROKU_EMAIL:
         required: true
 jobs:
-  deploy:
-    name: Deploy
+  build-and-deploy:
+    name: Build and deploy application
     runs-on: ubuntu-latest
     steps:
 
@@ -34,11 +34,10 @@ jobs:
         with:
           node: ${{ inputs.node }}
 
-      - name: Download build directory
-        uses: actions/download-artifact@v3
+      - name: Build
+        uses: ./.github/actions/build-app
         with:
-          name: 'build-${{ inputs.app }}'
-          path: "${{ inputs.app && format('apps/{0}/', inputs.app) }}dist"
+          app: ${{ inputs.app }}
 
       - name: Deploy
         uses: ./.github/actions/deploy-to-heroku
@@ -51,7 +50,7 @@ jobs:
   test:
     name: Test
     needs:
-      - deploy
+      - build-and-deploy
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -70,7 +69,7 @@ jobs:
         uses: './.github/actions/test-app'
         with:
           app: ${{ inputs.app }}
-          base-url: ${{ needs.deploy.outputs.deploy-url }}
+          base-url: https://${{ secrets.HEROKU_APP_NAME }}.herokuapp.com
           browser: ${{ matrix.browser }}
           cypress-project-id: ${{ secrets.CYPRESS_PROJECT_ID }}
           cypress-record-key: ${{ secrets.CYPRESS_RECORD_KEY }}
@@ -84,5 +83,5 @@ jobs:
           app: ${{ inputs.app }}
           baseline-branch: ${{ inputs.production-branch }}
           smoke: true
-          target: ${{ needs.deploy.outputs.deploy-url }}
+          target: https://${{ secrets.HEROKU_APP_NAME }}.herokuapp.com
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-to-netlify.yml
+++ b/.github/workflows/deploy-to-netlify.yml
@@ -23,8 +23,8 @@ on:
       NETLIFY_SITE_ID:
         required: true
 jobs:
-  deploy:
-    name: Deploy
+  build-and-deploy:
+    name: Build and deploy application
     runs-on: ubuntu-latest
     outputs:
       deploy-url: ${{ steps.deploy.outputs.deploy-url }}
@@ -38,11 +38,10 @@ jobs:
         with:
           node: ${{ inputs.node }}
 
-      - name: Download build directory
-        uses: actions/download-artifact@v3
+      - name: Build
+        uses: ./.github/actions/build-app
         with:
-          name: 'build-${{ inputs.app }}'
-          path: "${{ inputs.app && format('apps/{0}/', inputs.app) }}dist"
+          app: ${{ inputs.app }}
 
       - name: Deploy
         id: deploy
@@ -57,7 +56,7 @@ jobs:
   test:
     name: Test
     needs:
-      - deploy
+      - build-and-deploy
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -76,7 +75,7 @@ jobs:
         uses: './.github/actions/test-app'
         with:
           app: ${{ inputs.app }}
-          base-url: ${{ needs.deploy.outputs.deploy-url }}
+          base-url: ${{ needs.build-and-deploy.outputs.deploy-url }}
           browser: ${{ matrix.browser }}
           cypress-project-id: ${{ secrets.CYPRESS_PROJECT_ID }}
           cypress-record-key: ${{ secrets.CYPRESS_RECORD_KEY }}
@@ -90,5 +89,5 @@ jobs:
           app: ${{ inputs.app }}
           baseline-branch: ${{ inputs.production-branch }}
           smoke: true
-          target: ${{ needs.deploy.outputs.deploy-url }}
+          target: ${{ needs.build-and-deploy.outputs.deploy-url }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy
+on:
+  push:
+jobs:
+  chromatic:
+    name: Chromatic
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          node: 16
+
+      - name: Push Storybook to Chromatic
+        uses: chromaui/action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          buildScriptName: 'build:storybook'
+          autoAcceptChanges: master
+          exitZeroOnChanges: true
+          exitOnceUploaded: true
+
+  deploy-docs-to-netlify:
+    name: Deploy to Netlify and test
+    uses: './.github/workflows/deploy-to-netlify.yml'
+    with:
+      app: govuk-docs
+      node: 16
+      production-branch: master
+    secrets:
+      CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
+      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/update-built-files.yml
+++ b/.github/workflows/update-built-files.yml
@@ -1,0 +1,31 @@
+name: Update built files
+on:
+  push:
+    branches: [ 'master' ]
+jobs:
+  common:
+    name: Build files
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          node: 16
+
+      - name: Run unit tests
+        uses: ./.github/actions/test-code
+
+      - name: Scan code-base
+        uses: ./.github/actions/scan-code
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update built files
+        uses: ./.github/actions/update-built-files
+        with:
+          baseline-branch: 'master'
+

--- a/lib-govuk/create/Makefile
+++ b/lib-govuk/create/Makefile
@@ -46,7 +46,7 @@ $(dist_dir)/package.base.json: $(source_dir)/package.json
 	$(strip_package) '$(<)' > '$(@)'
 	$(patch_package) '$(@)'
 
-$(dist_dir)/package.app.json: $(plopfile) $(build_dir)/.github/workflows/main.yml
+$(dist_dir)/package.app.json: $(plopfile) $(build_dir)/.github/workflows/change-assurance.yml
 	mkdir -p '$(@D)'
 	./node_modules/.bin/plop --plopfile '$(plopfile)' app 'template' 'Template' 'Template.' 'n'
 	$(strip_package) '$(docs_source_dir)/package.json' > '$(@)'

--- a/lib/app-plop-pack/skel/.github/workflows/deploy.deploy.yml.hbs
+++ b/lib/app-plop-pack/skel/.github/workflows/deploy.deploy.yml.hbs
@@ -10,8 +10,6 @@
 {{else}}
     if: github.event_name == 'push' && github.branch == 'refs/heads/{{{ branch }}}'
 {{/if}}
-    needs:
-      - build-app
     uses: './.github/workflows/deploy-to-{{{ target }}}.yml'
     with:
 {{#unless standalone}}

--- a/lib/app-plop-pack/src/index.js
+++ b/lib/app-plop-pack/src/index.js
@@ -138,8 +138,8 @@ const plopFunction = async (plop) => {
       return [
         {
           type: 'append',
-          path: `${gitRoot}.github/workflows/main.yml`,
-          templateFile: '../skel/.github/workflows/main.deploy.yml.hbs'
+          path: `${gitRoot}.github/workflows/deploy.yml`,
+          templateFile: '../skel/.github/workflows/deploy.deploy.yml.hbs'
         },
         `Pipeline created; once you have set-up your secrets (${secrets}) in GitHub, your changes will be automatically deployed to ${answers.target} whenever to push to the ${answers.branch}.`
       ];

--- a/lib/create/Makefile
+++ b/lib/create/Makefile
@@ -7,6 +7,7 @@ source_dir = ../..
 target_dir = $(build_dir)/skel
 ci_sources := $(wildcard \
 	$(source_dir)/.github/actions/*/* \
+	$(source_dir)/.github/workflows/analysis.yml \
 	$(source_dir)/.github/workflows/deploy-to-netlify.yml \
 	$(source_dir)/.github/workflows/deploy-to-heroku.yml \
 	$(source_dir)/.jest/*/* \
@@ -50,7 +51,8 @@ docs_sources := $(wildcard \
 ci_deps = $(patsubst $(source_dir)/%,$(target_dir)/%,$(ci_sources))
 skel_deps = \
 	$(ci_deps) \
-	$(target_dir)/.github/workflows/main.yml \
+	$(target_dir)/.github/workflows/change-assurance.yml \
+	$(target_dir)/.github/workflows/deploy.yml \
 	$(patsubst $(source_dir)/%,$(target_dir)/%,$(sources)) \
 	$(patsubst $(docs_source_dir)/%,$(docs_target_dir)/%,$(docs_sources)) \
 	$(target_dir)/plopfile.mjs \
@@ -72,7 +74,7 @@ $(dist_dir)/package.base.json: $(source_dir)/package.json
 	$(strip_package) '$(<)' > '$(@)'
 	$(patch_package) '$(@)'
 
-$(build_dir)/skel-prototype/package.json: $(plopfile) $(target_dir)/.github/workflows/main.yml $(ci_deps)
+$(build_dir)/skel-prototype/package.json: $(plopfile) $(target_dir)/.github/workflows/change-assurance.yml $(ci_deps)
 	./node_modules/.bin/plop --plopfile '$(plopfile)' app 'docs' 'Documentation' 'Documentation website.'
 	$(cp) -r '$(target_dir)/apps/docs/' '$(@D)'
 	$(cp) -r '$(target_dir)/.github/' '$(@D)/.github'
@@ -80,7 +82,7 @@ $(build_dir)/skel-prototype/package.json: $(plopfile) $(target_dir)/.github/work
 	$(cp) '$(target_dir)/cypress.json' '$(@D)'
 	$(cp) '$(target_dir)/jest.config.base.js' '$(@D)/jest.config.base.js'
 	sed -i 's/..\/..\/jest.config.base/.\/jest.config.base/' '$(@D)/jest.config.js'
-	rm '$(@D)/README.md' '$(@D)/tsconfig.json' '$(@D)/.github/actions/setup/action.yml' '$(@D)/.github/workflows/main.yml'
+	rm '$(@D)/README.md' '$(@D)/tsconfig.json' '$(@D)/.github/actions/setup/action.yml' '$(@D)/.github/workflows/change-assurance.yml' '$(@D)/.github/workflows/deploy.yml'
 
 $(build_dir)/skel-prototype/tsconfig.json: $(source_dir)/tsconfig.json $(source_dir)/tsconfig.webpack.json $(build_dir)/skel-prototype/package.json
 	mkdir -p '$(@D)'
@@ -110,9 +112,13 @@ $(docs_target_dir)/%: $(docs_source_dir)/% $(docs_target_dir)/package.json
 	mkdir -p '$(@D)'
 	$(cp) '$(<)' '$(@D)'
 
-$(target_dir)/.github/workflows/main.yml: $(source_dir)/.github/workflows/main.yml
+$(target_dir)/.github/workflows/change-assurance.yml: $(source_dir)/.github/workflows/change-assurance.yml
 	mkdir -p '$(@D)'
-	sed -n '/deploy-/q;p' '$(<)' | sed 's/app: \[.*\]/app: []/' > '$(@)'
+	sed 's/app: \[.*\]/app: []/' '$(<)' > '$(@)'
+
+$(target_dir)/.github/workflows/deploy.yml: $(source_dir)/.github/workflows/deploy.yml
+	mkdir -p '$(@D)'
+	sed -n '/deploy-/q;p' '$(<)' > '$(@)'
 
 $(target_dir)/plopfile.mjs: $(source_dir)/plopfile.mjs
 	mkdir -p '$(@D)'

--- a/lib/create/plopfile.js
+++ b/lib/create/plopfile.js
@@ -212,8 +212,13 @@ export const plopFile = plop => {
       },
       {
         type: 'copy',
-        destination: '.github/workflows/main.yml',
-        source: 'skel/prototype/.github/workflows/main.yml'
+        destination: '.github/workflows/change-assurance.yml',
+        source: 'skel/prototype/.github/workflows/change-assurance.yml'
+      },
+      {
+        type: 'copy',
+        destination: '.github/workflows/deploy.yml',
+        source: 'skel/prototype/.github/workflows/deploy.yml'
       },
       {
         type: 'merge',

--- a/lib/create/skel/prototype/.github/workflows/change-assurance.yml
+++ b/lib/create/skel/prototype/.github/workflows/change-assurance.yml
@@ -1,0 +1,80 @@
+name: Change assurance
+on:
+  pull_request:
+jobs:
+  common:
+    name: Dependencies, Unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ '14', '16', '18' ]
+    steps:
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          node: ${{ matrix.node }}
+
+      - name: Run unit tests
+        uses: ./.github/actions/test-code
+
+  build-app:
+    name: Build application
+    needs:
+      - common
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          node: 16
+
+      - name: Build
+        uses: ./.github/actions/build-app
+
+      - name: Save build directory
+        uses: actions/upload-artifact@v3
+        with:
+          name: 'build'
+          path: "dist"
+          if-no-files-found: error
+          retention-days: 2
+
+  test-app:
+    name: Test application
+    needs:
+      - build-app
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        browser: [ 'chromium', 'firefox', 'electron' ]
+    steps:
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          node: 16
+
+      - name: Download build directory
+        uses: actions/download-artifact@v3
+        with:
+          name: 'build'
+          path: "dist"
+
+      - name: Run functional tests
+        uses: './.github/actions/test-app'
+        with:
+          browser: ${{ matrix.browser }}
+          cypress-project-id: ${{ secrets.CYPRESS_PROJECT_ID }}
+          cypress-record-key: ${{ secrets.CYPRESS_RECORD_KEY }}
+          node: ${{ matrix.node }}

--- a/lib/create/skel/prototype/.github/workflows/deploy.yml
+++ b/lib/create/skel/prototype/.github/workflows/deploy.yml
@@ -1,0 +1,4 @@
+name: Deploy
+on:
+  push:
+jobs:

--- a/lib/plop-pack/src/generators/app.js
+++ b/lib/plop-pack/src/generators/app.js
@@ -104,13 +104,13 @@ export const generator = {
     },
     {
       type: 'modify',
-      path: '.github/workflows/main.yml',
+      path: '.github/workflows/change-assurance.yml',
       pattern: /app: \[(.+?)( ?)\]/g,
       template: 'app: [$1, \'{{{name}}}\'$2]'
     },
     {
       type: 'modify',
-      path: '.github/workflows/main.yml',
+      path: '.github/workflows/change-assurance.yml',
       pattern: /app: \[\]/g,
       template: 'app: [ \'{{{name}}}\' ]'
     }


### PR DESCRIPTION
Not splitting Main leads to duplication of work between pull requests
and pushes. This should also allow us to better support external PRs.