### PR TITLE
Improve hint and error ARIA logic in Form controls

### DIFF
--- a/components/form-group/src/FormGroup.tsx
+++ b/components/form-group/src/FormGroup.tsx
@@ -35,6 +35,9 @@ export const FormGroup: FC<FormGroupProps> = ({
   ];
   const classes = classBuilder('govuk-form-group', classBlock, classModifiers, className);
   const hintId = _hintId || `${id}-hint`;
+  const errorId = `${id}-error`;
+  const describedById = error ? errorId : hint && hintId;
+  
   const children = (
     <Fragment>
       { !hint ? null : <Hint id={hintId}>{hint}</Hint> }
@@ -51,7 +54,7 @@ export const FormGroup: FC<FormGroupProps> = ({
             {children}
           </Fragment>
         ) : (
-          <FieldSet aria-describedby={hintId} legend={label}>
+          <FieldSet aria-describedby={describedById} legend={label}>
             {children}
           </FieldSet>
       ) }

--- a/components/form-group/src/FormGroup.tsx
+++ b/components/form-group/src/FormGroup.tsx
@@ -9,6 +9,7 @@ import '../assets/FormGroup.scss';
 
 export type FormGroupProps = StandardProps & Omit<HTMLAttributes<HTMLDivElement>, 'id' | 'label'> & {
   error?: ReactNode
+  errorId?: string
   fieldId?: string
   hint?: ReactNode
   hintId?: string
@@ -22,6 +23,7 @@ export const FormGroup: FC<FormGroupProps> = ({
   classModifiers: _classModifiers = [],
   className,
   error,
+  errorId: _errorId,
   fieldId,
   hint,
   hintId: _hintId,
@@ -35,8 +37,14 @@ export const FormGroup: FC<FormGroupProps> = ({
   ];
   const classes = classBuilder('govuk-form-group', classBlock, classModifiers, className);
   const hintId = _hintId || `${id}-hint`;
-  const errorId = `${id}-error`;
-  const describedById = error ? errorId : hint && hintId;
+  const errorId = _errorId || `${id}-error`;
+  const describedBy = ([
+    hint && hintId,
+    error && errorId
+  ]
+    .filter(e => e)
+    .join(' ') || undefined
+  );
   
   const children = (
     <Fragment>
@@ -54,7 +62,7 @@ export const FormGroup: FC<FormGroupProps> = ({
             {children}
           </Fragment>
         ) : (
-          <FieldSet aria-describedby={describedById} legend={label}>
+          <FieldSet aria-describedby={describedBy} legend={label}>
             {children}
           </FieldSet>
       ) }

--- a/components/form-group/src/FormGroup.tsx
+++ b/components/form-group/src/FormGroup.tsx
@@ -49,7 +49,7 @@ export const FormGroup: FC<FormGroupProps> = ({
   const children = (
     <Fragment>
       { !hint ? null : <Hint id={hintId}>{hint}</Hint> }
-      { !error ? null : <ErrorMessage id={`${id}-error`}>{error}</ErrorMessage>}
+      { !error ? null : <ErrorMessage id={errorId}>{error}</ErrorMessage>}
       {_children}
     </Fragment>
   );

--- a/components/text-input/src/TextInput.tsx
+++ b/components/text-input/src/TextInput.tsx
@@ -34,7 +34,13 @@ export const TextInput: FC<TextInputProps> = ({
   const fieldId = `${id}-input`;
   const hintId = `${id}-hint`;
   const errorId = `${id}-error`;
-  const describedById = error ? errorId : hint && hintId;
+  const describedBy = ([
+    hint && hintId,
+    error && errorId
+  ]
+    .filter(e => e)
+    .join(' ') || undefined
+  );
 
   return (
     <FormGroup
@@ -44,10 +50,11 @@ export const TextInput: FC<TextInputProps> = ({
       hint={hint}
       hintId={hintId}
       error={error}
+      errorId={errorId}
     >
       <Input
         {...attrs}
-        aria-describedby={describedById}
+        aria-describedby={describedBy}
         id={fieldId}
       />
     </FormGroup>

--- a/components/text-input/src/TextInput.tsx
+++ b/components/text-input/src/TextInput.tsx
@@ -33,6 +33,8 @@ export const TextInput: FC<TextInputProps> = ({
   const id = _id || attrs.name;
   const fieldId = `${id}-input`;
   const hintId = `${id}-hint`;
+  const errorId = `${id}-error`;
+  const describedById = error ? errorId : hint && hintId;
 
   return (
     <FormGroup
@@ -45,7 +47,7 @@ export const TextInput: FC<TextInputProps> = ({
     >
       <Input
         {...attrs}
-        aria-describedby={hint && hintId}
+        aria-describedby={describedById}
         id={fieldId}
       />
     </FormGroup>

--- a/components/textarea/src/Textarea.tsx
+++ b/components/textarea/src/Textarea.tsx
@@ -36,6 +36,9 @@ export const Textarea: FC<TextareaProps> = ({
   const id = _id || attrs.name;
   const fieldId = `${id}-input`;
   const hintId = `${id}-hint`;
+  const errorId = `${id}-error`;
+  const describedById = error ? errorId : hint && hintId;
+
   const maxWidth = width && (
     (((width >= 10) ? 4.76 : 1.76) + 1.81 * width) + 'ex'
   );
@@ -54,7 +57,7 @@ export const Textarea: FC<TextareaProps> = ({
     >
       <textarea
         {...attrs}
-        aria-describedby={hint && hintId}
+        aria-describedby={describedById}
         className={classes()}
         id={fieldId}
         rows={rows}

--- a/components/textarea/src/Textarea.tsx
+++ b/components/textarea/src/Textarea.tsx
@@ -37,7 +37,13 @@ export const Textarea: FC<TextareaProps> = ({
   const fieldId = `${id}-input`;
   const hintId = `${id}-hint`;
   const errorId = `${id}-error`;
-  const describedById = error ? errorId : hint && hintId;
+  const describedBy = ([
+    hint && hintId,
+    error && errorId
+  ]
+    .filter(e => e)
+    .join(' ') || undefined
+  );
 
   const maxWidth = width && (
     (((width >= 10) ? 4.76 : 1.76) + 1.81 * width) + 'ex'
@@ -54,10 +60,11 @@ export const Textarea: FC<TextareaProps> = ({
       hint={hint}
       hintId={hintId}
       error={error}
+      errorId={errorId}
     >
       <textarea
         {...attrs}
-        aria-describedby={describedById}
+        aria-describedby={describedBy}
         className={classes()}
         id={fieldId}
         rows={rows}

--- a/reports/.sastscan.baseline
+++ b/reports/.sastscan.baseline
@@ -3,5 +3,5 @@
     "scanPrimaryLocationHash": [],
     "scanTagsHash": []
   },
-  "created_at": "2022-10-25 12:31:20.895151"
+  "created_at": "2022-12-06 16:56:37.918467"
 }


### PR DESCRIPTION
- Update **TextInput**, **TextArea** and **FormGroup** (which automatically fixes **DateInput**, **Radios** and **Checkboxes**) components
- In above components the internal `aria-describedby` attribute only references the **hint** element by ID when it actually exists. This allows hint to be truly optional eliminating HTML validation and accessibility issues currently happening.
- Add logic in the same components to reference the error message by ID for `aria-describedby` when error message exists. When error message and hint both are present, referencing error takes priority.

I haven't added any new tests, but manually testing the components in Storybook, I can verify that  both issues raised in https://github.com/daniel-ac-martin/NotGovUK/issues/656 are fixed and the components work as expected.