### PR TITLE
Improve conditional rendering in Radios

### DIFF
--- a/components/radios/src/Radios.tsx
+++ b/components/radios/src/Radios.tsx
@@ -1,4 +1,4 @@
-import { FC, InputHTMLAttributes, ReactNode, createElement as h } from 'react';
+import { FC, InputHTMLAttributes, ReactNode, createElement as h, useState, SyntheticEvent } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 import { FormGroup } from '@not-govuk/form-group';
 import { Radio } from './Radio';
@@ -53,6 +53,8 @@ export const Radios: FC<RadiosProps> = ({
   const id = _id || attrs.name;
   const hintId = `${id}-hint`;
 
+  const [selectedId, setSelectedId] = useState<number | undefined>();
+
   return (
     <FormGroup
       id={id}
@@ -65,7 +67,7 @@ export const Radios: FC<RadiosProps> = ({
         {options.map((v, i) => {
           if (isOption(v)) {
             const optionId = `${id}-radio-${i}`;
-            const { selected, ...rest } = v;
+            const { selected, conditional, ...rest } = v;
             const defaultChecked = (
               defaultValue === undefined
               ? selected
@@ -80,10 +82,15 @@ export const Radios: FC<RadiosProps> = ({
               <Radio
                 {...rest}
                 {...attrs}
+                conditional={conditional}
                 classes={classes}
-                defaultChecked={defaultChecked}
+                aria-expanded={selectedId === i && Boolean(conditional) ? true : null}
+                defaultChecked={defaultChecked || selectedId === i}
                 id={optionId}
                 key={i}
+                onChange={(e: SyntheticEvent) => {
+                  setSelectedId(i);
+                }}
               />
             );
           } else {


### PR DESCRIPTION
- Apply `aria-expanded="true"` when Radio is selected (in response to https://github.com/daniel-ac-martin/NotGovUK/issues/654)
- Fix the conditional rendering logic, so when  radio is deselected, the conditional content is hidden.

## Screenshots

![ConditionalRadios](https://user-images.githubusercontent.com/6372869/212395520-143a3d85-c66a-40a2-8b4f-9647102f6a29.gif)
