### PR TITLE
CI: Split SCA from SAST

### DIFF
--- a/.github/actions/scan-code/action.yml
+++ b/.github/actions/scan-code/action.yml
@@ -1,9 +1,5 @@
 name: Scan code-base
 description: Scans the code-base for credentials and security vulnerabilities
-inputs:
-  token:
-    description: GitHub token
-    required: true
 runs:
   using: composite
   steps:
@@ -13,31 +9,5 @@ runs:
       with:
         languages: 'javascript'
 
-    - name: Cache vdb
-      uses: actions/cache@v3
-      with:
-        path: |
-          ${{ github.workspace }}/vdb
-        key: vdb-os_${{ runner.os }}
-
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-
-    - name: Scan
-      uses: ShiftLeftSecurity/scan-action@master
-      env:
-        DISABLE_TELEMETRY: 'true'
-        ENABLE_OSS_RISK: 'true'
-        FETCH_LICENSE: 'true'
-        VDB_HOME: ${{ github.workspace }}/vdb
-        WORKSPACE: https://github.com/${{ github.repository }}/blob/${{ github.sha }}
-        GITHUB_TOKEN: ${{ inputs.token }}
-      with:
-        type: json,yaml,serverless,dockerfile,kubernetes,depscan,bom
-        output: reports
-
-    - name: Upload scan reports
-      uses: actions/upload-artifact@master
-      with:
-        name: slscan-reports
-        path: reports

--- a/.github/actions/scan-dependencies/action.yml
+++ b/.github/actions/scan-dependencies/action.yml
@@ -1,0 +1,35 @@
+name: Scan dependencies
+description: Scans the dependencies for known security vulnerabilities
+inputs:
+  token:
+    description: GitHub token
+    required: true
+runs:
+  using: composite
+  steps:
+
+    - name: Cache vdb
+      uses: actions/cache@v3
+      with:
+        path: |
+          ${{ github.workspace }}/vdb
+        key: vdb-os_${{ runner.os }}
+
+    - name: Scan
+      uses: ShiftLeftSecurity/scan-action@master
+      env:
+        DISABLE_TELEMETRY: 'true'
+        ENABLE_OSS_RISK: 'true'
+        FETCH_LICENSE: 'true'
+        VDB_HOME: ${{ github.workspace }}/vdb
+        WORKSPACE: https://github.com/${{ github.repository }}/blob/${{ github.sha }}
+        GITHUB_TOKEN: ${{ inputs.token }}
+      with:
+        type: json,yaml,serverless,dockerfile,kubernetes,depscan,bom
+        output: reports
+
+    - name: Upload scan reports
+      uses: actions/upload-artifact@master
+      with:
+        name: slscan-reports
+        path: reports

--- a/.github/workflows/change-assurance.yml
+++ b/.github/workflows/change-assurance.yml
@@ -2,6 +2,21 @@ name: Change assurance
 on:
   pull_request:
 jobs:
+  analyse:
+    name: Analyse
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Scan code-base
+        uses: ./.github/actions/scan-code
+
   common:
     name: Dependencies, Unit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/static-security-analysis.yml
+++ b/.github/workflows/static-security-analysis.yml
@@ -1,7 +1,5 @@
-name: 'Analysis'
+name: 'Static Security Analysis'
 on:
-  pull_request:
-    branches: [ 'master' ]
   schedule:
     - cron: '35 1 * * 2'
 jobs:
@@ -18,12 +16,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Scan code-base
+        uses: ./.github/actions/scan-code
+
       - name: Setup
         uses: ./.github/actions/setup
         with:
           node: 16
 
-      - name: Scan code-base
-        uses: ./.github/actions/scan-code
+      - name: Scan dependencies
+        uses: ./.github/actions/scan-dependencies
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-built-files.yml
+++ b/.github/workflows/update-built-files.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           node: 16
 
-      - name: Scan code-base
-        uses: ./.github/actions/scan-code
+      - name: Scan dependencies
+        uses: ./.github/actions/scan-dependencies
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
SCA (dependency scanning) is slow and has little value in change assurance. This splits it out to be run only as a regular scan against the code-base.

SAST (CodeQL) is moved into the standard change assurance workflow.