### PR TITLE
Fix local dev environment

### DIFF
--- a/lib/asset-proxy/src/index.ts
+++ b/lib/asset-proxy/src/index.ts
@@ -1,5 +1,6 @@
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import { Configuration as WebpackConfig } from 'webpack';
+import { adaptCrudely } from '@not-govuk/express-adapter';
 import restify from '@not-govuk/restify';
 import { webpackMiddleware } from './lib/webpack';
 
@@ -29,7 +30,7 @@ export const assetProxy = ({
     bodyParser: false,
     name: `${name}-asset-proxy`
   });
-  const proxyMiddleware = createProxyMiddleware({
+  const proxyMiddleware = adaptCrudely(createProxyMiddleware({
     target: `http://localhost:${port + 1}`,
     changeOrigin: true,
     onProxyReq: (proxyReq, _req, res) => {
@@ -37,7 +38,7 @@ export const assetProxy = ({
 
       proxyReq.setHeader('X-Entrypoints', JSON.stringify(entrypoints));
     }
-  });
+  }));
   const close = httpd.close.bind(httpd);
 
   // Serve assets built by webpack

--- a/lib/express-adapter/src/index.ts
+++ b/lib/express-adapter/src/index.ts
@@ -94,4 +94,19 @@ export const adapt = (middleware: ExpressMiddleware): RestifyMiddleware => (req,
   }
 };
 
+// Some middlewares don't seem to work with a proxied Response object.
+// I'm not sure why. This function just provides the req and res objects
+// as-is but prevents any promises being passed to Restify as Restify
+// treats them differently.
+export const adaptCrudely = (middleware: ExpressMiddleware): RestifyMiddleware => (req, res, next) => {
+  const expressReq: Request = req as unknown as Request;
+  const expressRes: Response = res as unknown as Response;
+
+  if (isAsync(middleware)) {
+    middleware(expressReq, expressRes, next);
+  } else {
+    return middleware(expressReq, expressRes, next);
+  }
+};
+
 export default adapt;

--- a/lib/express-adapter/src/index.ts
+++ b/lib/express-adapter/src/index.ts
@@ -42,8 +42,8 @@ export const adapt = (middleware: ExpressMiddleware): RestifyMiddleware => (req,
     get(target, prop, receiver) {
       switch (prop) {
         case 'end':
-          return () => {
-            target.end();
+          return (chunk, encoding, callback) => {
+            target.end(chunk, encoding, callback);
             return next(false);
           }
         case 'redirect':

--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,7 @@
         "node"
       ],
       "groupName": "node",
-      "allowedVersions": "^[0-9]*[02468][.\\-]"
+      "allowedVersions": "/^[0-9]*[02468][.\\-]/"
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
It seems that the local dev environment has been broken since the last major Restify update (#684).

New versions of Restify now give special treatment to async middleware.
(Even refusing async functions that take a `next` parameter.) Therefore,
we must adapt them before passing them to Restify.