### PR TITLE
Checkboxes,Radios: Only set aria with a conditional

### DIFF
--- a/components/checkboxes/src/Checkbox.tsx
+++ b/components/checkboxes/src/Checkbox.tsx
@@ -44,7 +44,7 @@ export const Checkbox: FC<CheckboxProps> = ({
           ref={ref}
           onChange={onChange}
           aria-controls={conditional && conditionalId}
-          aria-expanded={!!(conditional && isChecked())}
+          aria-expanded={conditional && !!isChecked()}
         />
         <Label htmlFor={id} className={classes('label')}>{label}</Label>
         {hint && <Hint id={`${id}-hint`} className={classes('hint')}>{hint}</Hint>}

--- a/components/radios/src/Radio.tsx
+++ b/components/radios/src/Radio.tsx
@@ -34,7 +34,7 @@ export const Radio: FC<RadioProps> = ({
           type="radio"
           ref={ref}
           aria-controls={conditional && conditionalId}
-          aria-expanded={!!(conditional && isChecked())}
+          aria-expanded={conditional && !!isChecked()}
         />
         <Label htmlFor={id} className={classes('label')}>{label}</Label>
         {hint && <Hint id={`${id}-hint`} className={classes('hint')}>{hint}</Hint>}


### PR DESCRIPTION
Only sets the `aria-expanded` attribute when we have a conditional to display.