### PR TITLE
TextInput: Fix: Pass on class props

### DIFF
--- a/components/text-input/package.json
+++ b/components/text-input/package.json
@@ -24,7 +24,6 @@
     "react-components"
   ],
   "dependencies": {
-    "@not-govuk/component-helpers": "workspace:^0.7.1",
     "@not-govuk/form-group": "workspace:^0.7.1",
     "@not-govuk/input": "workspace:^0.7.1"
   },

--- a/components/text-input/src/TextInput.tsx
+++ b/components/text-input/src/TextInput.tsx
@@ -1,5 +1,4 @@
 import { FC, ReactNode, createElement as h } from 'react';
-import { classBuilder } from '@not-govuk/component-helpers';
 import { FormGroup } from '@not-govuk/form-group';
 import { Input, InputProps } from '@not-govuk/input';
 
@@ -29,7 +28,6 @@ export const TextInput: FC<TextInputProps> = ({
     error && 'error',
     ...(Array.isArray(_classModifiers) ? _classModifiers : [_classModifiers])
   ];
-  const classes = classBuilder('govuk-text-input', classBlock, classModifiers, className);
   const id = _id || attrs.name;
   const fieldId = `${id}-input`;
   const hintId = `${id}-hint`;
@@ -55,6 +53,9 @@ export const TextInput: FC<TextInputProps> = ({
       <Input
         {...attrs}
         aria-describedby={describedBy}
+        classBlock={classBlock}
+        classModifiers={classModifiers}
+        className={className}
         id={fieldId}
       />
     </FormGroup>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1326,7 +1326,6 @@ importers:
   components/text-input:
     specifiers:
       '@mdx-js/react': 1.6.22
-      '@not-govuk/component-helpers': workspace:^0.7.1
       '@not-govuk/component-test-helpers': workspace:^0.7.1
       '@not-govuk/form-group': workspace:^0.7.1
       '@not-govuk/input': workspace:^0.7.1
@@ -1336,7 +1335,6 @@ importers:
       ts-jest: 29.0.5
       typescript: 4.9.5
     dependencies:
-      '@not-govuk/component-helpers': link:../../lib/component-helpers
       '@not-govuk/form-group': link:../form-group
       '@not-govuk/input': link:../input
     devDependencies:


### PR DESCRIPTION
Without this, the error styling is not applied to the input.