### PR TITLE
Use base64 encoding in cookies

### DIFF
--- a/lib/consent-cookies/src/index.ts
+++ b/lib/consent-cookies/src/index.ts
@@ -35,7 +35,7 @@ export const consentCookies = ({
   secret,
   ...defaults
 }: ConsentCookiesOptions): Middleware => {
-  const cryptr = new Cryptr(secret);
+  const cryptr = new Cryptr(secret, { encoding: 'base64' });
   const encodeSecure = (v: any) => cryptr.encrypt(encodeClear(v));
   const decodeSecure = (v: any, req?: Request) => {
     try {

--- a/lib/engine/src/lib/auth/oidc.ts
+++ b/lib/engine/src/lib/auth/oidc.ts
@@ -160,7 +160,7 @@ export const oidcAuth: AuthBagger<AuthOptionsOIDC> = async ({
       //   1. We don't know what else is in the session
       //   2. Subsequent encryption will increase the size of the data
       const cookieLimit = 4096;
-      const encryptionCost = 2.2; // This is an estimate! - This should be reduced to 1.5 when we have base64 encoding
+      const encryptionCost = 1.5; // This is an estimate!
       const smallEnough = (v: object) => (
         JSON.stringify(v).length * encryptionCost <= cookieLimit
       );


### PR DESCRIPTION
This lets us fit more data into the cookies.