### PR TITLE
Fix OIDC

### DIFF
--- a/.github/actions/scan-app/action.yml
+++ b/.github/actions/scan-app/action.yml
@@ -31,7 +31,7 @@ runs:
       run: |
         PRETTY_TARGET="${TARGET#https://}"
         echo "write-issue=$([[ \"${GITHUB_REF#refs/heads/}\" != \"${BASELINE_BRANCH}\" ]] && echo 'false' || echo 'true')" >> ${GITHUB_OUTPUT}
-        echo "fail-action=$([[ \"${GITHUB_REF#refs/heads/}\" != \"${BASELINE_BRANCH}\" ]] && echo 'true' || true)" >> ${GITHUB_OUTPUT}
+        echo "fail-action=$([[ \"${GITHUB_REF#refs/heads/}\" != \"${BASELINE_BRANCH}\" ]] && echo 'true' || echo 'false')" >> ${GITHUB_OUTPUT}
         echo "prefix=${PRETTY_TARGET:-${APP}}" >> ${GITHUB_OUTPUT}
         echo "target=${TARGET:-http://localhost:8080}" >> ${GITHUB_OUTPUT}
 

--- a/lib/express-adapter/src/index.ts
+++ b/lib/express-adapter/src/index.ts
@@ -51,8 +51,11 @@ export const adapt = (middleware: ExpressMiddleware): RestifyMiddleware => (req,
       switch (prop) {
         case 'end':
           return (chunk, encoding, callback) => {
-            target.end(chunk, encoding, callback);
-            return next(false);
+            (target as any)._flushed = true; // This is a workaround for a bug that emerges when using Restify's gzip plugin
+            return target.end(chunk, encoding, () => {
+              callback && callback();
+              return next(false);
+            });
           }
         case 'redirect':
           return (_code: number | string, _uri?: string) => {


### PR DESCRIPTION
This is a workaround for and bug that arises when using Restify's gzip
plugin with the OIDC passport plugin (and presumably any other
middleware that calls `res.end()`.

Also corrects the value of a parameter for the Zap GitHub Action.