### PR TITLE
Allow frame ancestors

### DIFF
--- a/apps/govuk-template/src/server/config.ts
+++ b/apps/govuk-template/src/server/config.ts
@@ -36,6 +36,7 @@ const serverConfig = {
     secure: ( devMode ? defaultsFalse : defaultsTrue )(process.env.COOKIES_SECURE)
   },
   env,
+  frameAncestors: process.env.FRAME_ANCESTORS?.split(','),
   logger: {
     destination: process.env.LOG_DESTINATION,
     level: process.env.LOG_LEVEL || 'info'

--- a/apps/govuk-template/src/server/httpd.ts
+++ b/apps/govuk-template/src/server/httpd.ts
@@ -35,6 +35,7 @@ export const createServer = ({ entrypoints, port }: httpdOptions) => {
       secure: config.cookies.secure
     },
     env: config.env,
+    frameAncestors: config.frameAncestors,
     graphQL: {
       schema: graphQLSchema
     },

--- a/lib/engine/src/index.ts
+++ b/lib/engine/src/index.ts
@@ -3,7 +3,7 @@ import { createWriteStream } from 'fs';
 import { GraphQLSchema } from 'graphql';
 import { ComponentType } from 'react';
 import serverless from 'serverless-http';
-import restify, { IsReady, LogLevelString, LoggerOptions, Router } from '@not-govuk/restify';
+import restify, { CSPSources, IsReady, LogLevelString, LoggerOptions, Router, cspNone } from '@not-govuk/restify';
 import { PageLoader } from '@not-govuk/app-composer';
 import { consentCookies } from '@not-govuk/consent-cookies';
 import { ApplicationProps, ErrorPageProps, PageProps, reactRenderer } from '@not-govuk/server-renderer';
@@ -45,6 +45,7 @@ export type EngineOptions = {
     secure?: boolean
   }
   env: NodeEnv
+  frameAncestors?: CSPSources
   graphQL?: {
     schema: GraphQLSchema
   }
@@ -74,6 +75,7 @@ export const engine = async ({
   auth: authOptions,
   cookies: cookieOptions,
   env,
+  frameAncestors = cspNone,
   graphQL: _graphQL,
   httpd: { host, port },
   isReady,
@@ -139,6 +141,7 @@ export const engine = async ({
       'application/xhtml+xml; q=0.2': formatHTML,
       'text/html; q=0.2': formatHTML
     },
+    frameAncestors,
     isReady,
     logger
   });
@@ -255,6 +258,6 @@ export const engine = async ({
 
 export default engine;
 export { AuthMethod, SessionStore };
-export { Router, errors } from '@not-govuk/restify';
+export { Router, cspNone, cspSelf, errors } from '@not-govuk/restify';
 export { defaultsFalse, defaultsTrue } from './lib/config-helpers';
 export type { IsReady };

--- a/lib/plop-pack/skel/app/src/server/config.ts
+++ b/lib/plop-pack/skel/app/src/server/config.ts
@@ -36,6 +36,7 @@ const serverConfig = {
     secure: ( devMode ? defaultsFalse : defaultsTrue )(process.env.COOKIES_SECURE)
   },
   env,
+  frameAncestors: process.env.FRAME_ANCESTORS?.split(','),
   logger: {
     destination: process.env.LOG_DESTINATION,
     level: process.env.LOG_LEVEL || 'info'

--- a/lib/plop-pack/skel/app/src/server/httpd.ts
+++ b/lib/plop-pack/skel/app/src/server/httpd.ts
@@ -35,6 +35,7 @@ export const createServer = ({ entrypoints, port }: httpdOptions) => {
       secure: config.cookies.secure
     },
     env: config.env,
+    frameAncestors: config.frameAncestors,
     graphQL: {
       schema: graphQLSchema
     },

--- a/lib/restify/src/index.ts
+++ b/lib/restify/src/index.ts
@@ -4,7 +4,7 @@ import stoppable from 'stoppable';
 import { liveness } from './middleware/health-check';
 import { htmlByDefault } from './middleware/html-by-default';
 import { permissionsPolicy } from './middleware/permissions-policy';
-import { preventClickjacking } from './middleware/prevent-clickjacking';
+import { CSPSources, preventClickjacking } from './middleware/prevent-clickjacking';
 import { preventMimeSniffing } from './middleware/prevent-mime-sniffing';
 import { noCacheByDefault } from './middleware/no-cache-by-default';
 import { IsReady, readiness } from './middleware/readiness';
@@ -17,6 +17,7 @@ export type LoggerOptions = Omit<_LoggerOptions, 'name'> & {
 
 export type ServerOptions = _ServerOptions & {
   bodyParser?: plugins.BodyParserOptions | false
+  frameAncestors?: CSPSources
   grace?: number
   isReady?: IsReady
   liveness?: string
@@ -82,7 +83,7 @@ export const createServer = (options: ServerOptions ) => {
   httpd.pre(htmlByDefault(httpd));
 
   httpd.pre(permissionsPolicy);
-  httpd.pre(preventClickjacking);
+  httpd.pre(preventClickjacking({ frameAncestors: options.frameAncestors }));
   httpd.pre(preventMimeSniffing);
   httpd.pre(noCacheByDefault);
 
@@ -115,6 +116,7 @@ export const restify = {
 export default restify;
 export * as errors from 'restify-errors';
 export { Router } from './lib/router';
-export type { IsReady };
+export { cspNone, cspSelf } from './middleware/prevent-clickjacking';
+export type { IsReady, CSPSources };
 export type { LogLevelString } from './lib/logger';
 export type { Next, Request, Response, Middleware } from './middleware/common';


### PR DESCRIPTION
Allows the user to provide a `frameAncestors` option to the engine, which follows the [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) format. An equivalent environment variable has also been created.

## Examples
Only allow us to put our pages in frames:
```shell
FRAME_ANCESTORS="'self'"
```
**Note:** Pay attention to the single quotes!

Also allow example.com and its subdomains:
```shell
FRAME_ANCESTORS="'self',*example.com"
```

Allow all frames (not advised):
```shell
FRAME_ANCESTORS="*"
```

To disallow frames (default):
```shell
FRAME_ANCESTORS="'none'"
```

We disallow frames by default in order to prevent click jacking.

Partially addresses: #950