### PR TITLE
Add React v18 support

### DIFF
--- a/components-internal/anchor-list/package.json
+++ b/components-internal/anchor-list/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components-internal/anchor-list/src/AnchorList.tsx
+++ b/components-internal/anchor-list/src/AnchorList.tsx
@@ -19,7 +19,6 @@ export type AnchorListProps = StandardProps & {
 
 export const AnchorList: FC<AnchorListProps> = ({
   as: Component = 'ul',
-  children,
   classBlock,
   classModifiers,
   className,

--- a/components-internal/anchor/package.json
+++ b/components-internal/anchor/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components-internal/anchor/src/Anchor.tsx
+++ b/components-internal/anchor/src/Anchor.tsx
@@ -1,5 +1,5 @@
 import { Location } from 'history';
-import { AnchorHTMLAttributes, FC, createElement as h } from 'react';
+import { AnchorHTMLAttributes, FC, ReactNode, createElement as h } from 'react';
 import { match as Match } from 'react-router';
 import { NavHashLink } from 'react-router-hash-link';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
@@ -8,6 +8,7 @@ import { urlParse, useIsMounted, useLocation } from '@not-govuk/route-utils';
 import '../assets/Anchor.scss';
 
 export type AnchorProps = StandardProps & AnchorHTMLAttributes<HTMLAnchorElement> & {
+  children?: ReactNode
   /** Whether to force the link to be treated as external (useful for internal links that are NOT handled by the application) */
   forceExternal?: boolean
 };

--- a/components-internal/simple-table/package.json
+++ b/components-internal/simple-table/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components-internal/tabs/package.json
+++ b/components-internal/tabs/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components-internal/tabs/src/Tabs.tsx
+++ b/components-internal/tabs/src/Tabs.tsx
@@ -22,7 +22,6 @@ export type TabsProps = StandardProps & {
 };
 
 export const Tabs: FC<TabsProps> = ({
-  children,
   classBlock,
   classModifiers,
   className,

--- a/components/aside/package.json
+++ b/components/aside/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/aside/src/Aside.tsx
+++ b/components/aside/src/Aside.tsx
@@ -1,9 +1,10 @@
-import { FC, HTMLProps, createElement as h } from 'react';
+import { FC, HTMLProps, ReactNode, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 
 import '../assets/Aside.scss';
 
 export type AsideProps = StandardProps & HTMLProps<HTMLElement> & {
+  children?: ReactNode
 };
 
 export const Aside: FC<AsideProps> = ({ children, classBlock, classModifiers, className, ...attrs }) => {

--- a/components/back-link/package.json
+++ b/components/back-link/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/back-link/src/BackLink.tsx
+++ b/components/back-link/src/BackLink.tsx
@@ -1,4 +1,4 @@
-import { FC, createElement as h } from 'react';
+import { FC, ReactNode, createElement as h } from 'react';
 import { useHistory } from 'react-router-dom';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 import { A } from '@not-govuk/link';
@@ -6,18 +6,28 @@ import { A } from '@not-govuk/link';
 import '../assets/BackLink.scss';
 
 export type BackLinkProps = StandardProps & {
+  children?: ReactNode
   /** The location to link to */
-  href?: string,
+  href?: string
   /** The text of the link */
-  text?: string,
+  text?: string
   /** The title of the link */
   title?: string
 };
 
-export const BackLink: FC<BackLinkProps> = ({ children, classBlock, classModifiers, className, href, text = 'Back', ...attrs }) => {
+export const BackLink: FC<BackLinkProps> = ({
+  children,
+  classBlock,
+  classModifiers,
+  className,
+  href,
+  text: _text,
+  ...attrs
+}) => {
   const defaultClassBlock = 'govuk-back-link';
   const classes = classBuilder(defaultClassBlock, classBlock, classModifiers, className);
   const history = useHistory();
+  const text = _text || children || 'Back';
 
   return href ? (
     <A {...attrs}

--- a/components/breadcrumbs/package.json
+++ b/components/breadcrumbs/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/breadcrumbs/src/Breadcrumbs.tsx
+++ b/components/breadcrumbs/src/Breadcrumbs.tsx
@@ -10,7 +10,6 @@ export type BreadcrumbsProps = StandardProps & Pick<AnchorListProps, 'items'> & 
 };
 
 export const Breadcrumbs: FC<BreadcrumbsProps> = ({
-  children,
   classBlock,
   classModifiers,
   className,

--- a/components/button-group/package.json
+++ b/components/button-group/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/button-group/src/ButtonGroup.tsx
+++ b/components/button-group/src/ButtonGroup.tsx
@@ -1,9 +1,10 @@
-import { FC, HTMLAttributes, createElement as h } from 'react';
+import { FC, HTMLAttributes, ReactNode, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 
 import '../assets/ButtonGroup.scss';
 
 export type ButtonGroupProps = StandardProps & HTMLAttributes<HTMLDivElement> & {
+  children?: ReactNode
 };
 
 export const ButtonGroup: FC<ButtonGroupProps> = ({

--- a/components/button/package.json
+++ b/components/button/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/button/src/Button.tsx
+++ b/components/button/src/Button.tsx
@@ -1,10 +1,11 @@
-import { ButtonHTMLAttributes, ComponentProps, FC, Fragment, createElement as h } from 'react';
+import { ButtonHTMLAttributes, ComponentProps, FC, Fragment, ReactNode, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 import { A } from '@not-govuk/link';
 
 import '../assets/Button.scss';
 
 type CommonButtonProps = StandardProps & {
+  children?: ReactNode
   start?: boolean
 };
 type AnchorButtonProps = CommonButtonProps & ComponentProps<typeof A> & {

--- a/components/checkboxes/package.json
+++ b/components/checkboxes/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/checkboxes/src/Checkbox.tsx
+++ b/components/checkboxes/src/Checkbox.tsx
@@ -11,7 +11,6 @@ export type CheckboxProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'label'>
 };
 
 export const Checkbox: FC<CheckboxProps> = ({
-  children,
   classes,
   conditional,
   hint,

--- a/components/checkboxes/src/Checkboxes.tsx
+++ b/components/checkboxes/src/Checkboxes.tsx
@@ -37,7 +37,6 @@ export type CheckboxesProps = StandardProps & Omit<InputHTMLAttributes<HTMLInput
 };
 
 export const Checkboxes: FC<CheckboxesProps> = ({
-  children,
   classBlock,
   classModifiers,
   className,

--- a/components/cookie-banner/package.json
+++ b/components/cookie-banner/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/cookie-banner/src/CookieBanner.tsx
+++ b/components/cookie-banner/src/CookieBanner.tsx
@@ -23,7 +23,6 @@ export type CookieBannerProps = StandardProps & HTMLAttributes<HTMLDivElement> &
 
 export const CookieBanner: FC<CookieBannerProps> = ({
   'aria-label': ariaLabel= 'Cookie banner',
-  children,
   classBlock,
   classModifiers,
   className,

--- a/components/date-input/package.json
+++ b/components/date-input/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/date-input/src/DateInput.tsx
+++ b/components/date-input/src/DateInput.tsx
@@ -54,7 +54,6 @@ export type RawField<P, V> = FC<P> & WithFormat<V> & WithDeformat<V>
 
 export const DateInput: RawField<DateInputProps, DateInputValue> = ({
   autoComplete,
-  children,
   classBlock,
   classModifiers,
   className,

--- a/components/details/package.json
+++ b/components/details/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/details/src/Details.tsx
+++ b/components/details/src/Details.tsx
@@ -1,9 +1,10 @@
-import { FC, HTMLProps, createElement as h } from 'react';
+import { FC, HTMLProps, ReactNode, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 
 import '../assets/Details.scss';
 
 export type DetailsProps = StandardProps & HTMLProps<HTMLDetailsElement> & {
+  children?: ReactNode
   /** The summary of the content */
   summary: string
 };

--- a/components/error-message/package.json
+++ b/components/error-message/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/error-message/src/ErrorMessage.tsx
+++ b/components/error-message/src/ErrorMessage.tsx
@@ -1,10 +1,12 @@
-import { FC, HTMLAttributes, createElement as h } from 'react';
+import { FC, HTMLAttributes, ReactNode, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 import { VisuallyHidden } from '@not-govuk/visually-hidden';
 
 import '../assets/ErrorMessage.scss';
 
-export type ErrorMessageProps = StandardProps & HTMLAttributes<HTMLParagraphElement>;
+export type ErrorMessageProps = StandardProps & HTMLAttributes<HTMLParagraphElement> & {
+  children?: ReactNode
+};
 
 export const ErrorMessage: FC<ErrorMessageProps> = ({ children, classBlock, classModifiers, className, ...attrs }) => {
   const classes = classBuilder('govuk-error-message', classBlock, classModifiers, className);

--- a/components/error-summary/package.json
+++ b/components/error-summary/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/error-summary/src/ErrorSummary.tsx
+++ b/components/error-summary/src/ErrorSummary.tsx
@@ -12,7 +12,6 @@ export type ErrorSummaryProps = StandardProps & Pick<AnchorListProps, 'items'> &
 };
 
 export const ErrorSummary: FC<ErrorSummaryProps> = ({
-  children,
   classBlock,
   classModifiers,
   className,

--- a/components/fieldset/package.json
+++ b/components/fieldset/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/fieldset/src/FieldSet.tsx
+++ b/components/fieldset/src/FieldSet.tsx
@@ -4,6 +4,7 @@ import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 import '../assets/FieldSet.scss';
 
 export type FieldSetProps = StandardProps & FieldsetHTMLAttributes<HTMLFieldSetElement> & {
+  children?: ReactNode
   legend: ReactNode
 };
 

--- a/components/file-upload/package.json
+++ b/components/file-upload/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/file-upload/src/FileUpload.tsx
+++ b/components/file-upload/src/FileUpload.tsx
@@ -15,7 +15,6 @@ export type FileUploadProps = Omit<InputProps, 'type'> & {
 };
 
 export const FileUpload: FC<FileUploadProps> = ({
-  children,
   classBlock = 'govuk-file-upload',
   classModifiers: _classModifiers = [],
   className,

--- a/components/footer/package.json
+++ b/components/footer/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/footer/src/Footer.tsx
+++ b/components/footer/src/Footer.tsx
@@ -1,4 +1,4 @@
-import { FC, Fragment, createElement as h } from 'react';
+import { FC, Fragment, ReactNode, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 import { Link, LinkProps } from '@not-govuk/link';
 import { WidthContainer } from '@not-govuk/width-container';
@@ -22,6 +22,7 @@ export type NavMenu = {
 };
 
 export type FooterProps = StandardProps & {
+  children?: ReactNode
   /** Whether to add the standard Gov.UK content */
   govUK?: boolean
   /** Maximum width of the contents in px units (-1 for full width) */

--- a/components/footer/src/Footer.tsx
+++ b/components/footer/src/Footer.tsx
@@ -101,9 +101,7 @@ export const Footer: FC<FooterProps> = ({
                       <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
                     </svg>
                     <span className={classes('license-description')}>
-                      All content is available under the
-                      {' '}
-                      <A href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</A>, except where otherwise stated
+                      All content is available under the <A href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</A>, except where otherwise stated
                     </span>
                   </Fragment>
                 ) }

--- a/components/form-field/package.json
+++ b/components/form-field/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/form-group/package.json
+++ b/components/form-group/package.json
@@ -35,7 +35,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/form-group/src/FormGroup.tsx
+++ b/components/form-group/src/FormGroup.tsx
@@ -8,6 +8,7 @@ import { Label } from '@not-govuk/label';
 import '../assets/FormGroup.scss';
 
 export type FormGroupProps = StandardProps & Omit<HTMLAttributes<HTMLDivElement>, 'id' | 'label'> & {
+  children?: ReactNode
   error?: ReactNode
   errorId?: string
   fieldId?: string

--- a/components/form/package.json
+++ b/components/form/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/header/assets/Header.scss
+++ b/components/header/assets/Header.scss
@@ -32,6 +32,10 @@
     @extend .govuk-header__logotype-crown-fallback-image;
   }
 
+  &__logotype-text {
+    margin-left: 0.2em;
+  }
+
   &__link {
     &--small {
       @include govuk-font(24);

--- a/components/header/package.json
+++ b/components/header/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/header/src/Header.tsx
+++ b/components/header/src/Header.tsx
@@ -84,7 +84,6 @@ const departmentText = (d: string) => (
 );
 
 export const Header: FC<HeaderProps> = ({
-  children,
   classBlock,
   classModifiers,
   className,

--- a/components/header/src/Header.tsx
+++ b/components/header/src/Header.tsx
@@ -132,7 +132,6 @@ export const Header: FC<HeaderProps> = ({
                   <CoatLogo aria-hidden="true" focusable="false" className={classes('logotype-coat')} height="30" width="36" fallback={{ className: classes('logotype-coat-fallback-image') }} />
                 )
               }
-              &nbsp;
               <span className={classes('logotype-text')}>
                 {orgText}
               </span>

--- a/components/hint/package.json
+++ b/components/hint/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/hint/src/Hint.tsx
+++ b/components/hint/src/Hint.tsx
@@ -1,9 +1,11 @@
-import { FC, HTMLAttributes, createElement as h } from 'react';
+import { FC, HTMLAttributes, ReactNode, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 
 import '../assets/Hint.scss';
 
-export type HintProps = StandardProps & HTMLAttributes<HTMLDivElement>;
+export type HintProps = StandardProps & HTMLAttributes<HTMLDivElement> & {
+  children?: ReactNode
+};
 
 export const Hint: FC<HintProps> = ({ children, classBlock, classModifiers, className, ...attrs }) => {
   const classes = classBuilder('govuk-hint', classBlock, classModifiers, className);

--- a/components/input/package.json
+++ b/components/input/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/input/src/Input.tsx
+++ b/components/input/src/Input.tsx
@@ -13,7 +13,6 @@ export type InputProps = StandardProps & InputHTMLAttributes<HTMLInputElement> &
 };
 
 export const Input: FC<InputProps> = ({
-  children,
   classBlock,
   classModifiers,
   className,

--- a/components/inset-text/package.json
+++ b/components/inset-text/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/inset-text/src/InsetText.tsx
+++ b/components/inset-text/src/InsetText.tsx
@@ -1,9 +1,10 @@
-import { FC, createElement as h } from 'react';
+import { FC, ReactNode, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 
 import '../assets/InsetText.scss';
 
 export type InsetTextProps = StandardProps & {
+  children?: ReactNode
 };
 
 export const InsetText: FC<InsetTextProps> = ({ children, classBlock, classModifiers, className, ...attrs }) => {

--- a/components/label/package.json
+++ b/components/label/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/label/src/Label.tsx
+++ b/components/label/src/Label.tsx
@@ -1,9 +1,11 @@
-import { FC, LabelHTMLAttributes, createElement as h } from 'react';
+import { FC, LabelHTMLAttributes, ReactNode, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 
 import '../assets/Label.scss';
 
-export type LabelProps = StandardProps & LabelHTMLAttributes<HTMLLabelElement>;
+export type LabelProps = StandardProps & LabelHTMLAttributes<HTMLLabelElement> & {
+  children?: ReactNode
+};
 
 export const Label: FC<LabelProps> = ({ children, classBlock, classModifiers, className, ...attrs }) => {
   const classes = classBuilder('govuk-label', classBlock, classModifiers, className);

--- a/components/link/package.json
+++ b/components/link/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/navigation-menu/package.json
+++ b/components/navigation-menu/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/navigation-menu/src/NavigationMenu.tsx
+++ b/components/navigation-menu/src/NavigationMenu.tsx
@@ -16,7 +16,6 @@ export type NavigationMenuProps = StandardProps & HTMLAttributes<HTMLElement> & 
 };
 
 export const NavigationMenu: FC<NavigationMenuProps> = ({
-  children,
   classBlock,
   classModifiers,
   className,

--- a/components/notification-banner/package.json
+++ b/components/notification-banner/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/page/package.json
+++ b/components/page/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/page/src/Page.tsx
+++ b/components/page/src/Page.tsx
@@ -23,6 +23,8 @@ export type PageProps = (
     backHref?: string
     /** List of links */
     breadcrumbs?: Breadcrumb[]
+    /** The content that displays in the page. */
+    children?: ReactNode
     /** HRef for providing feedback on the service */
     feedbackHref?: string
     /** Content for the footer */

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/pagination/src/ItemEllipsis.tsx
+++ b/components/pagination/src/ItemEllipsis.tsx
@@ -4,7 +4,6 @@ import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 export type ItemEllipsisProps = StandardProps & HTMLAttributes<HTMLElement>;
 
 export const ItemEllipsis: FC<ItemEllipsisProps> = ({
-  children,
   classBlock,
   classModifiers = 'ellipses',
   className,

--- a/components/panel/package.json
+++ b/components/panel/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/panel/src/Panel.tsx
+++ b/components/panel/src/Panel.tsx
@@ -1,9 +1,11 @@
-import { FC, createElement as h } from 'react';
+import { FC, ReactNode, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 
 import '../assets/Panel.scss';
 
 export type PanelProps = StandardProps & {
+  /** The content that displays in the panel */
+  children?: ReactNode
   /** Heading of the panel */
   title?: string
 };

--- a/components/phase-banner/package.json
+++ b/components/phase-banner/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/phase-banner/src/PhaseBanner.tsx
+++ b/components/phase-banner/src/PhaseBanner.tsx
@@ -1,10 +1,11 @@
-import { FC, HTMLProps, createElement as h } from 'react';
+import { FC, HTMLProps, ReactNode, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 import { Tag } from '@not-govuk/tag';
 
 import '../assets/PhaseBanner.scss';
 
 export type PhaseBannerProps = StandardProps & HTMLProps<HTMLDivElement> & {
+  children?: ReactNode
   /** The phase the service is in */
   phase: string
 };

--- a/components/radios/package.json
+++ b/components/radios/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/radios/src/Radio.tsx
+++ b/components/radios/src/Radio.tsx
@@ -11,7 +11,6 @@ export type RadioProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'label'> & 
 };
 
 export const Radio: FC<RadioProps> = ({
-  children,
   classes,
   conditional,
   hint,

--- a/components/radios/src/Radios.tsx
+++ b/components/radios/src/Radios.tsx
@@ -36,7 +36,6 @@ export type RadiosProps = StandardProps & Omit<InputHTMLAttributes<HTMLInputElem
 };
 
 export const Radios: FC<RadiosProps> = ({
-  children,
   classBlock,
   classModifiers,
   className,

--- a/components/select/package.json
+++ b/components/select/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/select/src/Select.tsx
+++ b/components/select/src/Select.tsx
@@ -29,7 +29,6 @@ export type SelectProps = StandardProps & Omit<SelectHTMLAttributes<HTMLSelectEl
 };
 
 export const Select: FC<SelectProps> = ({
-  children,
   classBlock,
   classModifiers: _classModifiers = [],
   className,

--- a/components/skip-link/package.json
+++ b/components/skip-link/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/skip-link/src/SkipLink.tsx
+++ b/components/skip-link/src/SkipLink.tsx
@@ -1,9 +1,10 @@
-import { HTMLProps, FC, createElement as h } from 'react';
+import { HTMLProps, FC, ReactNode, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 
 import '../assets/SkipLink.scss';
 
 export type SkipLinkProps = StandardProps & Omit<HTMLProps<HTMLAnchorElement>, 'href'> & {
+  children?: ReactNode
   /** ID of the element to skip to */
   for: string
 };

--- a/components/summary-card/package.json
+++ b/components/summary-card/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/summary-list/package.json
+++ b/components/summary-list/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/summary-list/src/SummaryList.tsx
+++ b/components/summary-list/src/SummaryList.tsx
@@ -10,7 +10,6 @@ export type SummaryListProps = SummaryListContainerProps & {
 };
 
 const SummaryListComponent: FC<SummaryListProps> = ({
-  children,
   classBlock = 'govuk-summary-list',
   items,
   ...props

--- a/components/summary-list/src/SummaryListContainer.tsx
+++ b/components/summary-list/src/SummaryListContainer.tsx
@@ -1,7 +1,8 @@
-import { FC, HTMLAttributes, createElement as h } from 'react';
+import { FC, HTMLAttributes, ReactNode, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 
 export type SummaryListContainerProps = StandardProps & HTMLAttributes<HTMLDListElement> & {
+  children?: ReactNode
 };
 
 export const SummaryListContainer: FC<SummaryListContainerProps> = ({

--- a/components/table/package.json
+++ b/components/table/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/tabs/package.json
+++ b/components/tabs/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/tabs/src/Tabs.tsx
+++ b/components/tabs/src/Tabs.tsx
@@ -16,7 +16,6 @@ export type TabsProps = StandardProps & {
 };
 
 export const Tabs: FC<TabsProps> = ({
-  children,
   classBlock,
   classModifiers,
   className,

--- a/components/tag/package.json
+++ b/components/tag/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/tag/src/Tag.tsx
+++ b/components/tag/src/Tag.tsx
@@ -1,9 +1,10 @@
-import { FC, createElement as h } from 'react';
+import { FC, ReactNode, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 
 import '../assets/Tag.scss';
 
 export type TagProps = StandardProps & {
+  children?: ReactNode
   /** Text to be displayed within the tag */
   text?: string
 };

--- a/components/text-input/package.json
+++ b/components/text-input/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/text-input/src/TextInput.tsx
+++ b/components/text-input/src/TextInput.tsx
@@ -14,7 +14,6 @@ export type TextInputProps = InputProps & {
 };
 
 export const TextInput: FC<TextInputProps> = ({
-  children,
   classBlock,
   classModifiers: _classModifiers = [],
   className,

--- a/components/textarea/package.json
+++ b/components/textarea/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/textarea/src/Textarea.tsx
+++ b/components/textarea/src/Textarea.tsx
@@ -16,7 +16,6 @@ export type TextareaProps = StandardProps & TextareaHTMLAttributes<HTMLTextAreaE
 };
 
 export const Textarea: FC<TextareaProps> = ({
-  children,
   classBlock,
   classModifiers: _classModifiers = [],
   className,

--- a/components/visually-hidden/package.json
+++ b/components/visually-hidden/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/visually-hidden/src/VisuallyHidden.tsx
+++ b/components/visually-hidden/src/VisuallyHidden.tsx
@@ -1,9 +1,11 @@
-import { FC, HTMLAttributes, createElement as h } from 'react';
+import { FC, HTMLAttributes, ReactNode, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 
 import '../assets/VisuallyHidden.scss';
 
-export type VisuallyHiddenProps = StandardProps & HTMLAttributes<HTMLSpanElement>;
+export type VisuallyHiddenProps = StandardProps & HTMLAttributes<HTMLSpanElement> & {
+  children?: ReactNode
+};
 
 export const VisuallyHidden: FC<VisuallyHiddenProps> = ({ children, classBlock, classModifiers, className, ...attrs }) => {
   const classes = classBuilder('govuk-visually-hidden', classBlock, classModifiers, className);

--- a/components/warning-text/package.json
+++ b/components/warning-text/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/warning-text/src/WarningText.tsx
+++ b/components/warning-text/src/WarningText.tsx
@@ -1,9 +1,10 @@
-import { FC, createElement as h } from 'react';
+import { FC, ReactNode, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 
 import '../assets/WarningText.scss';
 
 export type WarningTextProps = StandardProps & {
+  children?: ReactNode
   /** Hidden text to be read out by a screen-reader prior to the warning */
   assistiveText?: string
 };

--- a/components/width-container/package.json
+++ b/components/width-container/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.9.1",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/width-container/src/WidthContainer.tsx
+++ b/components/width-container/src/WidthContainer.tsx
@@ -1,9 +1,10 @@
-import { FC, HTMLAttributes, createElement as h } from 'react';
+import { FC, HTMLAttributes, ReactNode, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 
 import '../assets/WidthContainer.scss';
 
 export type WidthContainerProps = StandardProps & HTMLAttributes<HTMLDivElement> & {
+  children?: ReactNode
   /** Maximum width of the container in px units (-1 for full width) */
   maxWidth?: number
 };

--- a/lib/component-test-helpers/src/index.ts
+++ b/lib/component-test-helpers/src/index.ts
@@ -1,4 +1,4 @@
-import { FC, ReactElement, createElement as h } from 'react';
+import { FC, ReactElement, ReactNode, createElement as h } from 'react';
 import { HelmetProvider } from 'react-helmet-async';
 import { MemoryRouter } from 'react-router';
 import { render as _render, RenderOptions } from '@testing-library/react';
@@ -6,7 +6,7 @@ import userEventDefault from '@testing-library/user-event';
 
 import '@testing-library/jest-dom';
 
-const Providers: FC<{ routerProps?: object }> = ({
+const Providers: FC<{ children?: ReactNode, routerProps?: object }> = ({
   children,
   routerProps
 }) => (

--- a/lib/docs-components/src/ReactPreview.tsx
+++ b/lib/docs-components/src/ReactPreview.tsx
@@ -57,6 +57,7 @@ const renderToMarkup = (x: ReactNode) => renderToStaticMarkup(
 );
 
 export type ReactPreviewProps = Omit<StandardProps, 'id'> & {
+  children?: ReactNode
   /** 'id' attribute to place on the base HTML element */
   id: string
   /** The React.js source-code of the children. */

--- a/lib/docs-components/src/index.ts
+++ b/lib/docs-components/src/index.ts
@@ -1,4 +1,4 @@
-import { ComponentProps, FC, Fragment, ReactElement, createElement as h } from 'react';
+import { ComponentProps, FC, Fragment, ReactElement, ReactNode, createElement as h } from 'react';
 import { id } from '@not-govuk/component-helpers';
 import { ReactPreview } from './ReactPreview';
 import { useDocs } from './context';
@@ -25,6 +25,7 @@ export const Meta: FC<MetaProps> = (props) => {
 };
 
 export type PreviewProps = ComponentProps<typeof _Preview> & {
+  children?: ReactNode
   id?: string
 };
 
@@ -54,6 +55,7 @@ export const Preview: FC<PreviewProps> = (props) => (
 );
 
 export type StoryProps = ComponentProps<typeof _Story> & {
+  children?: ReactNode
 };
 
 export const Story: FC<StoryProps> = ({ children }) => (
@@ -61,6 +63,7 @@ export const Story: FC<StoryProps> = ({ children }) => (
 );
 
 export type AddContextProps = ComponentProps<typeof _AddContext> & {
+  children?: ReactNode
 };
 
 export const AddContext: FC<AddContextProps> = ({ children }) => (

--- a/lib/forms/src/form.tsx
+++ b/lib/forms/src/form.tsx
@@ -1,9 +1,10 @@
-import { FC, Fragment, HTMLProps, createElement as h } from 'react';
+import { FC, Fragment, HTMLProps, ReactNode, createElement as h } from 'react';
 import { FormikProps } from 'formik';
 
 const prettyPrint = (obj: object) => JSON.stringify(obj, undefined, 2);
 
 export type FormProps = HTMLProps<HTMLFormElement> & FormikProps<any> & {
+  children?: ReactNode
   debug?: boolean
 };
 

--- a/lib/forms/src/formik-form.ts
+++ b/lib/forms/src/formik-form.ts
@@ -9,7 +9,10 @@ type HTMLFormPropsMini = Omit<HTMLFormProps, 'onSubmit' | 'onReset'>;
 // It would be nice to replace this with the vanilla withFormik but there
 // appears to be some difference in the implementation.
 const withFormik = <Values, A>(options: FormikConfig<Values>) => (Component: ComponentType<A & FormikProps<Values>>): FC<A> => props => (
-  h(Formik, options, (formik: FormikProps<Values>) => h(Component, {...props, ...formik}))
+  h(Formik, {
+    ...options,
+    children: (formik: FormikProps<Values>) => h(Component, {...props, ...formik})
+  })
 );
 
 const wireUpForm = <Values>(Component: ComponentType<HTMLFormProps>): FC<HTMLFormPropsMini & FormikProps<Values>> => ({

--- a/lib/forms/src/index.ts
+++ b/lib/forms/src/index.ts
@@ -1,4 +1,4 @@
-import { FC, createElement as h } from 'react';
+import { FC, ReactNode, createElement as h } from 'react';
 import reactDomServer from 'react-dom/server';
 import { StaticRouter } from 'react-router';
 import { useHistory } from 'react-router-dom';
@@ -46,6 +46,7 @@ type Method = 'get' | 'post';
 
 export type FormProps<T> = StandardProps & {
   action: string
+  children?: ReactNode
   debug?: boolean
   initialValues?: T
   method: Method

--- a/lib/server-renderer/package.json
+++ b/lib/server-renderer/package.json
@@ -20,7 +20,6 @@
   "license": "MIT",
   "dependencies": {
     "@not-govuk/app-composer": "workspace:^0.9.1",
-    "js-beautify": "^1.15.1",
     "restify-errors": "^8.0.2"
   },
   "peerDependencies": {
@@ -29,7 +28,6 @@
   },
   "devDependencies": {
     "@not-govuk/restify": "workspace:^0.9.1",
-    "@types/js-beautify": "1.14.3",
     "@types/node": "20.12.2",
     "@types/react": "16.14.60",
     "@types/react-dom": "16.9.24",

--- a/lib/server-renderer/src/HelmetHead.tsx
+++ b/lib/server-renderer/src/HelmetHead.tsx
@@ -1,4 +1,4 @@
-import { FC, createElement as h } from 'react';
+import { FC, Fragment, ReactNode, createElement as h } from 'react';
 import { HelmetServerState } from 'react-helmet-async';
 import { Hydration, HydrationData } from '@not-govuk/app-composer';
 
@@ -32,9 +32,9 @@ window.hydration = ${JSON.stringify(hydration)?.replace(/</g, '\\u003c')};
   return (
     <head>
       <meta charSet={charSet} />
-      {helmet.title.toComponent()}
-      {helmet.meta.toComponent()}
-      {helmet.link.toComponent()}
+      {helmet.title.toComponent() as any}
+      {helmet.meta.toComponent() as any}
+      {helmet.link.toComponent() as any}
       { stylesheets.map( v => (
         <link key={v} href={`${assetsPath}${v}`} rel="stylesheet" />
       ) ) }

--- a/lib/server-renderer/src/index.ts
+++ b/lib/server-renderer/src/index.ts
@@ -1,7 +1,6 @@
 import { GraphQLSchema } from 'graphql';
 import { ComponentType, createElement as h } from 'react';
 import { renderToString } from 'react-dom/server';
-import { html as beautifyHtml } from 'js-beautify';
 import { ApplicationProps, ErrorPageProps, PageProps, PageInfoSSR, UserInfo, compose, renderToStringWithData } from '@not-govuk/app-composer';
 import { htmlEnvelope } from './html-envelope';
 
@@ -199,11 +198,7 @@ export const reactRenderer: ReactRenderer = ({
       });
       const html = env.head + appRender + env.foot;
 
-      return beautifyHtml(html,
-        {
-          'indent_with_tabs': true
-        }
-      );
+      return html;
     };
 
     return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1931,22 +1931,18 @@ importers:
     specifiers:
       '@not-govuk/app-composer': workspace:^0.9.1
       '@not-govuk/restify': workspace:^0.9.1
-      '@types/js-beautify': 1.14.3
       '@types/node': 20.12.2
       '@types/react': 16.14.60
       '@types/react-dom': 16.9.24
       graphql: 15.9.0
-      js-beautify: ^1.15.1
       react-helmet-async: 1.3.0
       restify-errors: ^8.0.2
       typescript: 4.9.5
     dependencies:
       '@not-govuk/app-composer': link:../app-composer
-      js-beautify: 1.15.1
       restify-errors: 8.0.2
     devDependencies:
       '@not-govuk/restify': link:../restify
-      '@types/js-beautify': 1.14.3
       '@types/node': 20.12.2
       '@types/react': 16.14.60
       '@types/react-dom': 16.9.24
@@ -5862,18 +5858,6 @@ packages:
       '@hapi/hoek': 9.3.0
     dev: true
 
-  /@isaacs/cliui/8.0.2:
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: /string-width/4.2.3
-      strip-ansi: 7.1.0
-      strip-ansi-cjs: /strip-ansi/6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: /wrap-ansi/7.0.0
-    dev: false
-
   /@istanbuljs/load-nyc-config/1.1.0:
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
     engines: {node: '>=8'}
@@ -6306,17 +6290,6 @@ packages:
     dependencies:
       mkdirp: 1.0.4
       rimraf: 3.0.2
-
-  /@one-ini/wasm/0.1.1:
-    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
-    dev: false
-
-  /@pkgjs/parseargs/0.11.0:
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /@pmmmwh/react-refresh-webpack-plugin/0.5.10_6w6chkt6mub7yppqv232tkxg3a:
     resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
@@ -8890,7 +8863,7 @@ packages:
       react-docgen-typescript: 2.2.2_typescript@4.9.5
       tslib: 2.6.3
       typescript: 4.9.5
-      webpack: 5.93.0
+      webpack: 5.93.0_webpack-cli@5.1.4
     transitivePeerDependencies:
       - supports-color
 
@@ -9692,10 +9665,6 @@ packages:
       expect: 29.5.0
       pretty-format: 29.5.0
 
-  /@types/js-beautify/1.14.3:
-    resolution: {integrity: sha512-FMbQHz+qd9DoGvgLHxeqqVPaNRffpIu5ZjozwV8hf9JAGpIOzuAf4wGbRSo8LNITHqGjmmVjaMggTT5P4v4IHg==}
-    dev: true
-
   /@types/jsdom/20.0.1:
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
     dependencies:
@@ -10265,11 +10234,6 @@ packages:
     deprecated: Use your platform's native atob() and btoa() methods instead
     dev: true
 
-  /abbrev/2.0.0:
-    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dev: false
-
   /abort-controller/3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -10501,11 +10465,6 @@ packages:
   /ansi-styles/5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
-
-  /ansi-styles/6.2.1:
-    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
-    engines: {node: '>=12'}
-    dev: false
 
   /ansi-to-html/0.6.15:
     resolution: {integrity: sha512-28ijx2aHJGdzbs+O5SNQF65r6rrKYnkuwTYm8lZlChuoJ9P1vVzIpWO20sQTqTPDXYp6NFwk326vApTtLVFXpQ==}
@@ -11327,6 +11286,7 @@ packages:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
     dependencies:
       balanced-match: 1.0.2
+    dev: true
 
   /braces/2.3.2:
     resolution: {integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==}
@@ -12145,13 +12105,6 @@ packages:
       readable-stream: 2.3.8
       typedarray: 0.0.6
 
-  /config-chain/1.1.13:
-    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
-    dependencies:
-      ini: 1.3.8
-      proto-list: 1.2.4
-    dev: false
-
   /console-browserify/1.2.0:
     resolution: {integrity: sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==}
 
@@ -12420,7 +12373,7 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 2.7.1
       semver: 6.3.1
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@5.1.4
 
   /css-loader/5.2.7_webpack@5.93.0:
     resolution: {integrity: sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==}
@@ -13107,26 +13060,11 @@ packages:
       es5-ext: 0.10.62
     dev: true
 
-  /eastasianwidth/0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-    dev: false
-
   /ecc-jsbn/0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
     dependencies:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
-
-  /editorconfig/1.0.4:
-    resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dependencies:
-      '@one-ini/wasm': 0.1.1
-      commander: 10.0.1
-      minimatch: 9.0.1
-      semver: 7.6.3
-    dev: false
 
   /ee-first/1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -13166,10 +13104,6 @@ packages:
 
   /emoji-regex/8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  /emoji-regex/9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-    dev: false
 
   /emojis-list/3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
@@ -13912,7 +13846,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@5.1.4
 
   /file-system-cache/1.1.0:
     resolution: {integrity: sha512-IzF5MBq+5CR0jXx5RxPe4BICl/oEhBSXKaL9fLhAXrIfIUS77Hr4vzrYyqYMHN6uTt+BOqi3fDCTjjEBCjERKw==}
@@ -14172,14 +14106,6 @@ packages:
       cross-spawn: 7.0.3
       signal-exit: 3.0.7
 
-  /foreground-child/3.1.1:
-    resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
-    engines: {node: '>=14'}
-    dependencies:
-      cross-spawn: 7.0.3
-      signal-exit: 4.1.0
-    dev: false
-
   /forever-agent/0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
     dev: true
@@ -14205,7 +14131,7 @@ packages:
       semver: 5.7.2
       tapable: 1.1.3
       typescript: 4.9.5
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@5.1.4
       worker-rpc: 0.1.1
     transitivePeerDependencies:
       - supports-color
@@ -14597,18 +14523,6 @@ packages:
 
   /glob-to-regexp/0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
-
-  /glob/10.3.10:
-    resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    hasBin: true
-    dependencies:
-      foreground-child: 3.1.1
-      jackspeak: 2.3.6
-      minimatch: 9.0.3
-      minipass: 5.0.0
-      path-scurry: 1.10.1
-    dev: false
 
   /glob/6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
@@ -15128,7 +15042,7 @@ packages:
       pretty-error: 2.1.2
       tapable: 1.1.3
       util.promisify: 1.0.0
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@5.1.4
 
   /html-webpack-plugin/5.5.0_webpack@5.93.0:
     resolution: {integrity: sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==}
@@ -16006,15 +15920,6 @@ packages:
       es-get-iterator: 1.1.3
       iterate-iterator: 1.0.2
 
-  /jackspeak/2.3.6:
-    resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
-    dev: false
-
   /jake/10.9.1:
     resolution: {integrity: sha512-61btcOHNnLnsOdtLgA5efqQWjnSi/vow5HbI7HMdKKWqvrKR1bLK3BPlJn9gcSaP2ewuamUSMB5XEy76KUIS2w==}
     engines: {node: '>=10'}
@@ -16616,23 +16521,6 @@ packages:
     resolution: {integrity: sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==}
     dev: false
 
-  /js-beautify/1.15.1:
-    resolution: {integrity: sha512-ESjNzSlt/sWE8sciZH8kBF8BPlwXPwhR6pWKAw8bw4Bwj+iZcnKW6ONWUutJ7eObuBZQpiIb8S7OYspWrKt7rA==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dependencies:
-      config-chain: 1.1.13
-      editorconfig: 1.0.4
-      glob: 10.3.10
-      js-cookie: 3.0.5
-      nopt: 7.2.0
-    dev: false
-
-  /js-cookie/3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
-    dev: false
-
   /js-string-escape/1.0.1:
     resolution: {integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==}
     engines: {node: '>= 0.8'}
@@ -17119,11 +17007,6 @@ packages:
       highlight.js: 10.7.3
     dev: true
 
-  /lru-cache/10.1.0:
-    resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
-    engines: {node: 14 || >=16.14}
-    dev: false
-
   /lru-cache/5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
     dependencies:
@@ -17464,20 +17347,6 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
-  /minimatch/9.0.1:
-    resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dependencies:
-      brace-expansion: 2.0.1
-    dev: false
-
-  /minimatch/9.0.3:
-    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dependencies:
-      brace-expansion: 2.0.1
-    dev: false
-
   /minimist/1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -17814,14 +17683,6 @@ packages:
 
   /node-releases/2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
-
-  /nopt/7.2.0:
-    resolution: {integrity: sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    hasBin: true
-    dependencies:
-      abbrev: 2.0.0
-    dev: false
 
   /normalize-package-data/2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -18432,14 +18293,6 @@ packages:
     dependencies:
       path-root-regex: 0.1.2
 
-  /path-scurry/1.10.1:
-    resolution: {integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dependencies:
-      lru-cache: 10.1.0
-      minipass: 5.0.0
-    dev: false
-
   /path-to-regexp/0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
 
@@ -18661,7 +18514,7 @@ packages:
       postcss: 7.0.39
       schema-utils: 3.3.0
       semver: 7.6.3
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@5.1.4
 
   /postcss-modules-extract-imports/2.0.0:
     resolution: {integrity: sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==}
@@ -18954,10 +18807,6 @@ packages:
     dependencies:
       xtend: 4.0.2
 
-  /proto-list/1.2.4:
-    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
-    dev: false
-
   /proxy-addr/2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -19115,7 +18964,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@5.1.4
 
   /react-docgen-typescript/2.2.2:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
@@ -20290,11 +20139,6 @@ packages:
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
-  /signal-exit/4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
-    dev: false
-
   /simple-git/3.16.1_supports-color@8.1.1:
     resolution: {integrity: sha512-xzRxMKiy1zEYeHGXgAzvuXffDS0xgsq07Oi4LWEEcVH29vLpcZ2tyQRWyK0NLLlCVaKysZeem5tC1qHEOxsKwA==}
     dependencies:
@@ -20685,15 +20529,6 @@ packages:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
-  /string-width/5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.1.0
-    dev: false
-
   /string.prototype.matchall/4.0.8:
     resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
     dependencies:
@@ -20837,7 +20672,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 2.7.1
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@5.1.4
 
   /style-loader/2.0.0_webpack@5.93.0:
     resolution: {integrity: sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==}
@@ -21016,7 +20851,7 @@ packages:
       serialize-javascript: 5.0.1
       source-map: 0.6.1
       terser: 5.27.1
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@5.1.4
       webpack-sources: 1.4.3
     transitivePeerDependencies:
       - bluebird
@@ -21679,7 +21514,7 @@ packages:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@5.1.4
 
   /url-parse/1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
@@ -21985,7 +21820,7 @@ packages:
       mime: 2.6.0
       mkdirp: 0.5.6
       range-parser: 1.2.1
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@5.1.4
       webpack-log: 2.0.0
 
   /webpack-dev-middleware/4.3.0_webpack@5.93.0:
@@ -22026,7 +21861,7 @@ packages:
     peerDependencies:
       webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
     dependencies:
-      webpack: 4.46.0
+      webpack: 4.46.0_webpack-cli@5.1.4
 
   /webpack-hot-middleware/2.26.1:
     resolution: {integrity: sha512-khZGfAeJx6I8K9zKohEWWYN6KDlVw2DHownoe+6Vtwj1LP9WFgegXnVMSkZ/dBEBtXFwrkkydsaPFlB7f8wU2A==}
@@ -22131,6 +21966,7 @@ packages:
       webpack-sources: 1.4.3
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /webpack/4.46.0_webpack-cli@5.1.4:
     resolution: {integrity: sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==}
@@ -22365,15 +22201,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  /wrap-ansi/8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      ansi-styles: 6.2.1
-      string-width: 5.1.2
-      strip-ansi: 7.1.0
-    dev: false
 
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}


### PR DESCRIPTION
Allows the components to be run under React v18, and prepares some of the libraries for React v18.

Also includes some minor tweaks to make hydration more seamless.

**Note:** The changes to the types are potentially a breaking change for some people.

closes: #1026 