### PR TITLE
Fix peer dependencies to include React v18

### DIFF
--- a/apps/govuk-docs/src/common/page-wrap.tsx
+++ b/apps/govuk-docs/src/common/page-wrap.tsx
@@ -29,7 +29,6 @@ export const PageWrap: FC<PageProps> = ({ children }) => {
         { href: "https://github.com/daniel-ac-martin/NotGovUK/issues/new", text: "Contact" },
       ]}
       organisationText="!GOV.UK"
-      phase="alpha"
       serviceName="NotGovUK"
       title="NotGovUK"
       maxContentsWidth={1100}

--- a/components-internal/anchor-list/package.json
+++ b/components-internal/anchor-list/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components-internal/anchor/package.json
+++ b/components-internal/anchor/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components-internal/simple-table/package.json
+++ b/components-internal/simple-table/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components-internal/tabs/package.json
+++ b/components-internal/tabs/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/aside/package.json
+++ b/components/aside/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/back-link/package.json
+++ b/components/back-link/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/breadcrumbs/package.json
+++ b/components/breadcrumbs/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/button-group/package.json
+++ b/components/button-group/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/button/package.json
+++ b/components/button/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/checkboxes/package.json
+++ b/components/checkboxes/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/cookie-banner/package.json
+++ b/components/cookie-banner/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/date-input/package.json
+++ b/components/date-input/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/details/package.json
+++ b/components/details/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/error-message/package.json
+++ b/components/error-message/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/error-summary/package.json
+++ b/components/error-summary/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/fieldset/package.json
+++ b/components/fieldset/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/file-upload/package.json
+++ b/components/file-upload/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/footer/package.json
+++ b/components/footer/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/form-field/package.json
+++ b/components/form-field/package.json
@@ -26,7 +26,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/form-group/package.json
+++ b/components/form-group/package.json
@@ -35,7 +35,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/form/package.json
+++ b/components/form/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/header/package.json
+++ b/components/header/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/hint/package.json
+++ b/components/hint/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/input/package.json
+++ b/components/input/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/inset-text/package.json
+++ b/components/inset-text/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/label/package.json
+++ b/components/label/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/link/package.json
+++ b/components/link/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/navigation-menu/package.json
+++ b/components/navigation-menu/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/notification-banner/package.json
+++ b/components/notification-banner/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/page/package.json
+++ b/components/page/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/panel/package.json
+++ b/components/panel/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/phase-banner/package.json
+++ b/components/phase-banner/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/radios/package.json
+++ b/components/radios/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/select/package.json
+++ b/components/select/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/skip-link/package.json
+++ b/components/skip-link/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/summary-card/package.json
+++ b/components/summary-card/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/summary-list/package.json
+++ b/components/summary-list/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/table/package.json
+++ b/components/table/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/tabs/package.json
+++ b/components/tabs/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/tag/package.json
+++ b/components/tag/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/text-input/package.json
+++ b/components/text-input/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/textarea/package.json
+++ b/components/textarea/package.json
@@ -32,7 +32,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/visually-hidden/package.json
+++ b/components/visually-hidden/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/warning-text/package.json
+++ b/components/warning-text/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/components/width-container/package.json
+++ b/components/width-container/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@not-govuk/docs-components": "^0.12.0",
     "@storybook/addon-docs": "^6.5.16",
-    "react": "^16.14.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "@not-govuk/docs-components": {

--- a/lib/app-composer/package.json
+++ b/lib/app-composer/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "@apollo/client": "^3.11.8",
     "@not-govuk/user-info": "^0.12.0",
-    "react": "^16.14.0",
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
     "react-helmet-async": "^2.0.5",
     "react-router": "^6.26.1",
     "react-router-dom": "^6.26.1"

--- a/lib/client-renderer/package.json
+++ b/lib/client-renderer/package.json
@@ -22,8 +22,8 @@
     "@not-govuk/app-composer": "workspace:^0.12.0"
   },
   "peerDependencies": {
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@types/react": "16.14.60",

--- a/lib/component-test-helpers/package.json
+++ b/lib/component-test-helpers/package.json
@@ -19,7 +19,7 @@
   "author": "Daniel A.C. Martin <npm@daniel-martin.co.uk> (http://daniel-martin.co.uk/)",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^16.14.0",
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
     "react-router": "^6.26.1"
   },
   "devDependencies": {

--- a/lib/docs-components/package.json
+++ b/lib/docs-components/package.json
@@ -33,7 +33,7 @@
     "prismjs-github": "^1.0.0"
   },
   "peerDependencies": {
-    "react": "^16.14.0",
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
     "react-helmet-async": "^2.0.5"
   },
   "devDependencies": {

--- a/lib/forms/package.json
+++ b/lib/forms/package.json
@@ -29,8 +29,8 @@
     "validator": "^13.12.0"
   },
   "peerDependencies": {
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0",
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.26.1"
   },
   "devDependencies": {

--- a/lib/server-renderer/package.json
+++ b/lib/server-renderer/package.json
@@ -23,8 +23,8 @@
     "restify-errors": "^8.0.2"
   },
   "peerDependencies": {
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@not-govuk/restify": "workspace:^0.12.0",

--- a/lib/user-info/package.json
+++ b/lib/user-info/package.json
@@ -22,7 +22,7 @@
     "react-components"
   ],
   "peerDependencies": {
-    "react": "^16.14.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@not-govuk/component-test-helpers": "workspace:^0.12.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -76,8 +76,8 @@
     "@not-govuk/warning-text": "workspace:^0.12.0"
   },
   "peerDependencies": {
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0",
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0",
     "react-router": "^6.26.1",
     "react-router-dom": "^6.26.1"
   },


### PR DESCRIPTION
Also removes the Alpha banner from the website, as the components are fairly mature.

closes: #1026 