### PR TITLE
Fix hydration warnings

### DIFF
--- a/lib/app-composer/src/index.ts
+++ b/lib/app-composer/src/index.ts
@@ -283,7 +283,7 @@ export const compose: Compose = options => {
 
     const router = h(
       Router, options.routerProps,
-      h(UserInfoProvider, {}, (
+      h(UserInfoProvider, {}, switchOrError /* (
         "LoadingPage" in options
         ? h(
           Suspense, { fallback: h(withPageWrap(options.LoadingPage)) },
@@ -293,7 +293,7 @@ export const compose: Compose = options => {
           Fragment, {},
           switchOrError
         )
-      ))
+      ) */ )
     );
 
     return h(

--- a/lib/restify/src/middleware/content-security-policy.ts
+++ b/lib/restify/src/middleware/content-security-policy.ts
@@ -33,7 +33,6 @@ const csp = ({
     'img-src': self, // Only load our own images (no hot-linking) - I think this is a good idea as it helps prevent tracking
     'manifest-src': self, // Only load our own manifests
     'media-src': self, // Only load our own media
-    'prefetch-src': self, // Only pre-fetch from ourselves
     'script-src': (
       process.env.NODE_ENV === 'development'
         ? [ self, `'nonce-${nonce}'`, unsafeEval ] // Looser policy for HMR in local-dev environment

--- a/lib/restify/src/middleware/permissions-policy.ts
+++ b/lib/restify/src/middleware/permissions-policy.ts
@@ -7,33 +7,56 @@ const keywords = [
 
 const ppObj = {
   'accelerometer': 'self',
-  'ambient-light-sensor': 'self',
+  'ambient-light-sensor': 'self', // Unsupported in Chrome
+  'attribution-reporting': 'self', // Unsupported in Chrome
   'autoplay': 'self',
-  'battery': 'self',
+  'battery': 'self', // Unsupported in Chrome
+  'bluetooth': 'self', // Unsupported in Chrome
+  'browsing-topics': 'self',
   'camera': 'self',
+  'clipboard-read': 'self',
+  'clipboard-write': 'self',
+  'compute-pressure': 'self',
+  'conversion-measurement': 'self', // Unsupported in Chrome
+  'cross-origin-isolated': 'self',
   'display-capture': 'self',
-  'document-domain': 'self',
+  'document-domain': 'self', // Unsupported in Chrome
   'encrypted-media': 'self',
-  'execution-while-not-rendered': 'self',
-  'execution-while-out-of-viewport': 'self',
+  'execution-while-not-rendered': 'self', // Unsupported in Chrome
+  'execution-while-out-of-viewport': 'self', // Unsupported in Chrome
+  'focus-without-user-activation': 'self', // Unsupported in Chrome
   'fullscreen': 'self',
   'gamepad': 'self',
   'geolocation': 'self',
   'gyroscope': 'self',
+  'keyboard-map': 'self',
   'hid': 'self',
+  'identity-credentials-get': 'self',
   'idle-detection': 'self',
+  'interest-cohort': 'self',
   'local-fonts': 'self',
   'magnetometer': 'self',
   'microphone': 'self',
   'midi': 'self',
+  'navigation-override': 'self', // Unsupported in Chrome
+  'otp-credentials': 'self',
   'payment': 'self',
   'picture-in-picture': 'self',
+  'publickey-credentials-create': 'self',
   'publickey-credentials-get': 'self',
   'screen-wake-lock': 'self',
   'serial': 'self',
-  'speaker-selection': 'self',
+  'speaker-selection': 'self', // Unsupported in Chrome
+  'storage-access': 'self',
+  'sync-script': 'self', // Unsupported in Chrome
+  'sync-xhr': 'self',
+  'trust-token-redemption': 'self', // Unsupported in Chrome
+  'unload': 'self',
   'usb': 'self',
-  'web-share': 'self',
+  'web-share': 'self', // Unsupported in Chrome
+  'window-management': 'self',
+  'window-placement': 'self', // Unsupported in Chrome
+  'vertical-scroll': 'self', // Unsupported in Chrome
   'xr-spatial-tracking': 'self'
 };
 

--- a/lib/restify/src/middleware/permissions-policy.ts
+++ b/lib/restify/src/middleware/permissions-policy.ts
@@ -13,7 +13,7 @@ const ppObj = {
   'camera': 'self',
   'display-capture': 'self',
   'document-domain': 'self',
-  'encrypted-media ': 'self',
+  'encrypted-media': 'self',
   'execution-while-not-rendered': 'self',
   'execution-while-out-of-viewport': 'self',
   'fullscreen': 'self',

--- a/lib/server-renderer/src/HelmetHead.tsx
+++ b/lib/server-renderer/src/HelmetHead.tsx
@@ -32,9 +32,9 @@ window.hydration = ${JSON.stringify(hydration)?.replace(/</g, '\\u003c')};
   return (
     <head>
       <meta charSet={charSet} />
-      {helmet.title.toComponent() as any}
-      {helmet.meta.toComponent() as any}
-      {helmet.link.toComponent() as any}
+      {helmet?.title.toComponent() as any}
+      {helmet?.meta.toComponent() as any}
+      {helmet?.link.toComponent() as any}
       { stylesheets.map( v => (
         <link key={v} href={`${assetsPath}${v}`} rel="stylesheet" />
       ) ) }

--- a/lib/server-renderer/src/html-envelope.ts
+++ b/lib/server-renderer/src/html-envelope.ts
@@ -38,19 +38,15 @@ export const htmlEnvelope: HtmlEnvelope = ({
   );
 
   return ({
-    head: `
-<!doctype html>
-<html ${helmet.htmlAttributes.toString()}>
+    head: `<!DOCTYPE html>
+<html ${helmet?.htmlAttributes.toString() || ''}>
   ${head}
-  <body ${helmet.bodyAttributes.toString()}>
-    <div id="${rootId}">
-`,
-    foot: `
-    </div>
+  <body ${helmet?.bodyAttributes.toString() || ''}>
+    <div id="${rootId}">`,
+    foot: `</div>
     ${scripts}
   </body>
-</html>
-`,
+</html>`,
   });
 };
 


### PR DESCRIPTION
These warnings will become errors in React v18.

We do two things:
  1. We remove whitespace between the tags that we are hydrating on
  2. We remove suspense from the server render for now, as we cannot use
     it on the client, and hydration requires an identical tree

Also fixes some bugs in the CSP and the Permissions-Policy.