### PR TITLE
Align Next.js interface with Remix interface

### DIFF
--- a/apps/next-example/next.config.mjs
+++ b/apps/next-example/next.config.mjs
@@ -10,9 +10,8 @@ const nextConfig = {
     ...config,
     plugins: [
       ...config.plugins,
-      new webpack.NormalModuleReplacementPlugin(/^react-helmet-async$/, '@not-govuk\/VOID-react-helmet-async'),
-      new webpack.NormalModuleReplacementPlugin(/^react-router$/, '@not-govuk\/VOID-react-router'),
-      new webpack.NormalModuleReplacementPlugin(/^react-router-dom$/, '@not-govuk\/VOID-react-router-dom'),
+      new webpack.NormalModuleReplacementPlugin(/^@not-govuk\/head$/, '@not-govuk\/head\/dummy'),
+      new webpack.NormalModuleReplacementPlugin(/^@not-govuk\/router$/, '@not-govuk\/router\/next'),
     ]
   })
 };

--- a/lib/router/package.json
+++ b/lib/router/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./next": "./src/next.ts",
     "./remix": "./src/remix.ts"
   },
   "publishConfig": {
@@ -14,6 +15,10 @@
       ".": {
         "default": "./dist/index.js",
         "types": "./dist/index.d.ts"
+      },
+      "./next": {
+        "default": "./dist/next.js",
+        "types": "./dist/next.d.ts"
       },
       "./remix": {
         "default": "./dist/remix.js",
@@ -59,6 +64,7 @@
     "@types/react": "^18.3.12",
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
+    "next": "15.0.3",
     "ts-jest": "29.2.5",
     "typescript": "4.9.5"
   }

--- a/lib/router/src/index.ts
+++ b/lib/router/src/index.ts
@@ -28,7 +28,7 @@ let Link: FC<LinkProps> = ({
   const href = (
     typeof to === 'string'
       ? to
-      : ( to.pathname || '' ) + ( to.search || '' ) + ( to.hash || '' )
+      : (to.pathname || '') + (to.search || '') + (to.hash || '')
   );
 
   return h('a', {
@@ -79,14 +79,19 @@ try {
             router.back();
           }
         } else {
+          const href = (
+            to === 'string'
+              ? to
+              : to.toString()
+          );
           const nextOptions = {
             scroll: !options.preventScrollReset
           };
 
           if (options.replace) {
-            router.replace(to, undefined, nextOptions);
+            router.replace(href, nextOptions);
           } else {
-            router.push(to, undefined, nextOptions);
+            router.push(href, nextOptions);
           }
         }
       };

--- a/lib/router/src/index.ts
+++ b/lib/router/src/index.ts
@@ -52,6 +52,7 @@ try {
   try {
     const { usePathname, useRouter, useSearchParams } = require('next/navigation');
     const _Link = require('next/link');
+    console.warn('Deprecated import; please import @not-govuk/router from @not-govuk/router/next when using Next.js.');
     _useLocation = () => {
       const pathname = usePathname();
       const searchParams = useSearchParams();

--- a/lib/router/src/next.ts
+++ b/lib/router/src/next.ts
@@ -1,0 +1,89 @@
+import type { FC } from 'react';
+import type { Location as _Location } from 'react-router';
+import type { LinkProps as _LinkProps } from 'react-router-dom';
+import type { NavigateFunction, NavigateOptions, To } from './common';
+import { createElement as h } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import _Link from 'next/link';
+import { UseIsActive, makeUseIsActive } from './is-active';
+import { UseLocation, makeUseLocation } from './location';
+
+export type LinkProps = Omit<_LinkProps, 'relative' | 'reloadDocument' | 'state' | 'unstable_viewTransition'>
+
+export const needSuspense = true;
+
+const _useLocation = () => {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const search = (
+    searchParams.size
+      ? '?' + searchParams.toString()
+      : ''
+  );
+  const location = {
+    state: undefined,
+    key: '',
+    pathname,
+    search,
+    hash: ''
+  };
+
+  return location;
+};
+
+export const useLocation: UseLocation = makeUseLocation(_useLocation);
+export const useIsActive: UseIsActive = makeUseIsActive(useLocation);
+
+export const useNavigate: NavigateFunction = () => {
+  const router = useRouter();
+
+  return (to: To | number, options: NavigateOptions = {}) => {
+    if (typeof to === 'number') {
+      if (to === -1) {
+        router.back();
+      }
+    } else {
+      const href = (
+        to === 'string'
+          ? to
+          : to.toString()
+      );
+      const nextOptions = {
+        scroll: !options.preventScrollReset
+      };
+
+      if (options.replace) {
+        router.replace(href, nextOptions);
+      } else {
+        router.push(href, nextOptions);
+      }
+    }
+  };
+};
+
+export const Link: FC<LinkProps> = ({
+  to,
+  preventScrollReset,
+  replace,
+  ...attrs
+}) => {
+  const href = (
+    typeof to === 'string'
+      ? to
+      : {
+        ...to,
+        hash: (
+          to.hash !== '#'
+            ? to.hash
+            : undefined
+        )
+      }
+  );
+
+  return h(_Link, {
+    ...attrs,
+    href,
+    replace,
+    scroll: !preventScrollReset
+  });
+};


### PR DESCRIPTION
Provides a new `next` export to the router package. i.e: `@not-govuk/router/next`

The use of the original export is now deprecated and will raise warnings. In a future version the old method will no longer work.