### PR TITLE
Manage package lock-file in CI

### DIFF
--- a/.github/actions/update-built-files/action.yml
+++ b/.github/actions/update-built-files/action.yml
@@ -20,6 +20,5 @@ runs:
       if: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', inputs.baseline-branch) }}
       run: |
         git add -f pnpm-lock.yaml
-        git add -f reports/.sastscan.baseline
         git commit -m "[skip ci] Update built files"
         git push

--- a/.github/workflows/update-built-files.yml
+++ b/.github/workflows/update-built-files.yml
@@ -21,11 +21,6 @@ jobs:
         with:
           node: 22
 
-      - name: Scan dependencies
-        uses: ./.github/actions/scan-dependencies
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Update built files
         uses: ./.github/actions/update-built-files
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 .sastscan.baseline
 coverage/
 node_modules/
+pnpm-lock.yaml
 storybook-static/


### PR DESCRIPTION
If we .gitignore this file, we should be able to manage it exclusively
in CI, which is probably easier and more secure.