### PR TITLE
Add ServiceNavigation component

### DIFF
--- a/apps/govuk-docs/src/common/stories.ts
+++ b/apps/govuk-docs/src/common/stories.ts
@@ -32,6 +32,7 @@ const mainStories = [
   require('../../../../components/phase-banner/spec/PhaseBanner.stories.mdx'),
   require('../../../../components/radios/spec/Radios.stories.mdx'),
   require('../../../../components/select/spec/Select.stories.mdx'),
+  require('../../../../components/service-navigation/spec/ServiceNavigation.stories.mdx'),
   require('../../../../components/skip-link/spec/SkipLink.stories.mdx'),
   require('../../../../components/summary-list/spec/SummaryList.stories.mdx'),
   require('../../../../components/table/spec/Table.stories.mdx'),

--- a/components/navigation-menu/spec/NavigationMenu.stories.mdx
+++ b/components/navigation-menu/spec/NavigationMenu.stories.mdx
@@ -51,6 +51,8 @@ A standard Navigation menu.
 
 ### Horizontal
 
+<p><Tag text="Deprecated" /></p>
+
 A horizontal Navigation menu that can be used as alternative to the main navigation menu.
 
 <Preview>

--- a/components/search-box/assets/SearchBox.scss
+++ b/components/search-box/assets/SearchBox.scss
@@ -24,7 +24,8 @@
     text-indent: -5000px;
     overflow: hidden;
 
-    &:hover {
+    &:hover,
+    &[disabled]:hover {
       background-color: color.adjust(govuk-colour("blue"), $lightness: 5%);
     }
 
@@ -64,6 +65,7 @@
 
       &:hover {
         background-color: color.adjust(govuk-colour("light-grey"), $lightness: 5%);
+        color: govuk-colour("black");
       }
     }
   }

--- a/components/search-box/assets/SearchBox.scss
+++ b/components/search-box/assets/SearchBox.scss
@@ -55,7 +55,7 @@
     transform: scale(0.5);
   }
 
-  &--hods {
+  &--secondary {
     .not-govuk-standalone-input__button {
       background-color: govuk-colour("light-grey");
       color: govuk-colour("black");

--- a/components/search-box/spec/SearchBox.stories.mdx
+++ b/components/search-box/spec/SearchBox.stories.mdx
@@ -114,5 +114,16 @@ Currently errors are visually hidden, so it is best to avoid them. They will how
 </Preview>
 
 
+### Secondary button
+
+A search box with a more subtle, grey button, similar to the 'secondary' button style.
+
+<Preview>
+  <Story name="Secondary">
+    <SearchBox name="q" classModifiers="secondary" />
+  </Story>
+</Preview>
+
+
 [Search component]: https://components.publishing.service.gov.uk/component-guide/search
 [GOV.UK Component Guide]: https://components.publishing.service.gov.uk/component-guide

--- a/components/service-navigation/.gitignore
+++ b/components/service-navigation/.gitignore
@@ -1,0 +1,5 @@
+dist/
+node_modules/
+package-lock.json
+pnpm-lock.yaml
+tsconfig.tsbuildinfo

--- a/components/service-navigation/README.md
+++ b/components/service-navigation/README.md
@@ -1,0 +1,78 @@
+NotGovUK - Service Navigation
+=============================
+
+A component to help users understand that they’re using your service and lets them navigate around your service.
+
+
+Using this package
+------------------
+
+First install the package into your project:
+
+```shell
+npm install -S @not-govuk/service-navigation
+```
+
+Then use it in your code as follows:
+
+```js
+import React, { createElement as h } from 'react';
+import ServiceNavigation from '@not-govuk/service-navigation';
+
+export const MyComponent = props => (
+  <ServiceNavigation items={[
+    {
+      href: "/#",
+      text: "Navigation item 1"
+    },
+    {
+      href: "#active",
+      text: "Navigation item 2",
+    },
+    {
+      href: "/#",
+      text: "Navigation item 3"
+    }
+  ]} />
+);
+
+export default MyComponent;
+```
+
+
+Working on this package
+-----------------------
+
+Before working on this package you must install its dependencies using
+the following command:
+
+```shell
+pnpm install
+```
+
+
+### Testing
+
+Run the unit tests.
+
+```shell
+npm test
+```
+
+
+### Building
+
+Build the package by compiling the TypeScript source code.
+
+```shell
+npm run build
+```
+
+
+### Clean-up
+
+Remove any previously built files.
+
+```shell
+npm run clean
+```

--- a/components/service-navigation/assets/ServiceNavigation.scss
+++ b/components/service-navigation/assets/ServiceNavigation.scss
@@ -1,0 +1,22 @@
+@import "@not-govuk/sass-base";
+@import "govuk-frontend/dist/govuk/components/service-navigation/index";
+
+.govuk-service-navigation {
+  &__list {
+    &__item {
+      @extend .govuk-service-navigation__item;
+
+      &--active {
+        @extend .govuk-service-navigation__item--active;
+      }
+    }
+
+    &__link {
+      @extend .govuk-service-navigation__link;
+
+      &--active {
+        @extend .govuk-service-navigation__link--active !optional;
+      }
+    }
+  }
+}

--- a/components/service-navigation/jest.config.js
+++ b/components/service-navigation/jest.config.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const baseConfig = require('../../jest.config.base');
+
+const config = {
+  ...baseConfig,
+  collectCoverageFrom: [
+    '<rootDir>/src/**.{ts,tsx}',
+  ],
+  testMatch: [
+    '<rootDir>/spec/**.{ts,tsx}'
+  ]
+};
+
+module.exports = config;

--- a/components/service-navigation/package.json
+++ b/components/service-navigation/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@not-govuk/service-navigation",
+  "version": "0.15.2",
+  "description": "A component to help users understand that they’re using your service and lets them navigate around your service.",
+  "main": "src/ServiceNavigation.tsx",
+  "sass": "assets/ServiceNavigation.scss",
+  "publishConfig": {
+    "main": "dist/ServiceNavigation.js",
+    "typings": "dist/ServiceNavigation.d.ts"
+  },
+  "files": [
+    "/assets",
+    "/dist"
+  ],
+  "scripts": {
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "prepublishOnly": "npm run clean && npm run build",
+    "build": "tsc",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo"
+  },
+  "author": "Daniel A.C. Martin <npm@daniel-martin.co.uk> (http://daniel-martin.co.uk/)",
+  "license": "MIT",
+  "keywords": [
+    "react-components"
+  ],
+  "dependencies": {
+    "@not-govuk/anchor-list": "workspace:^0.15.2",
+    "@not-govuk/component-helpers": "workspace:^0.15.2",
+    "@not-govuk/link": "workspace:^0.15.2",
+    "@not-govuk/sass-base": "workspace:^0.15.2",
+    "@not-govuk/width-container": "workspace:^0.15.2",
+    "govuk-frontend": "5.7.1"
+  },
+  "peerDependencies": {
+    "@not-govuk/docs-components": "^0.15.2",
+    "@storybook/addon-docs": "^6.5.16",
+    "react": "^18.3.1"
+  },
+  "peerDependenciesMeta": {
+    "@not-govuk/docs-components": {
+      "optional": true
+    },
+    "@storybook/addon-docs": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@mdx-js/react": "1.6.22",
+    "@not-govuk/component-test-helpers": "workspace:^0.15.2",
+    "@not-govuk/header": "workspace:^0.15.2",
+    "@types/react": "18.3.18",
+    "jest": "29.7.0",
+    "jest-environment-jsdom": "29.7.0",
+    "ts-jest": "29.2.5",
+    "typescript": "4.9.5"
+  }
+}

--- a/components/service-navigation/spec/ServiceNavigation.stories.mdx
+++ b/components/service-navigation/spec/ServiceNavigation.stories.mdx
@@ -1,0 +1,131 @@
+import { Fragment } from 'react';
+import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
+import { Header } from '@not-govuk/header';
+import { ServiceNavigation } from '../src/ServiceNavigation';
+import readMe from '../README.md';
+
+<Meta
+  title="Service navigation"
+  component={ ServiceNavigation }
+  parameters={ {
+    chromatic: { viewports: [640, 480] },
+    description: 'A component to help users understand that they’re using your service and lets them navigate around your service.',
+    jest: ['ServiceNavigation'],
+    notes: readMe
+  } }
+/>
+
+# Service navigation
+
+Service navigation helps users understand that they’re using your service and lets them navigate around your service.
+
+<Preview withToolbar>
+  <Story name="ServiceNavigation">
+    <ServiceNavigation items={[
+      {
+        href: "/#",
+        text: "Navigation item 1"
+      },
+      {
+        href: "#active",
+        text: "Navigation item 2",
+      },
+      {
+        href: "/#",
+        text: "Navigation item 3"
+      }
+    ]} />
+  </Story>
+</Preview>
+
+<Props of={ ServiceNavigation } />
+
+
+## When to use this component
+
+Use the Service navigation to help users understand that they’re using your service.
+
+To decide when to use navigation links in your service, see the [Help users to navigate a service pattern].
+
+
+## How it works
+
+Together, the [GOV.UK header component] and Service navigation component ensure users get a consistent experience on GOV.UK.
+
+This also assures users that they’re in the right place to use your service and to understand that GOV.UK functions as one website.
+
+For guidance on how to plan your header and navigation, see the [Help users navigate a service pattern].
+
+
+### Change the blue colour bar under the GOV.UK header to full width
+
+To use the GOV.UK header and Service navigation and make them fit together visually, you’ll need to change the bottom blue border of the GOV.UK header to full width.
+
+Apply a class `govuk-header--full-width-border` to the GOV.UK header.
+
+<Preview>
+  <Story name="With header">
+    <>
+    <Header govUK classModifiers="full-width-border" />
+    <ServiceNavigation items={[
+      {
+        href: "/#",
+        text: "Navigation item 1"
+      },
+      {
+        href: "#active",
+        text: "Navigation item 2",
+      },
+      {
+        href: "/#",
+        text: "Navigation item 3"
+      }
+    ]} />
+    </>
+  </Story>
+</Preview>
+
+
+### Showing your service name only
+
+We recommend that you use the Service navigation component to show your service name, instead of the GOV.UK header, and to start updating existing services.
+
+<Preview>
+  <Story name="Service name">
+    <ServiceNavigation serviceName="Service name" serviceHref="#" />
+  </Story>
+</Preview>
+
+
+### Showing service name and navigation links
+
+Show navigation links to let users navigate to different parts of your service and find useful links and tools.
+
+<Preview>
+  <Story name="Full">
+    <ServiceNavigation
+      serviceName="Service name"
+      serviceHref="#"
+      items={[
+        {
+          href: "/#",
+          text: "Navigation item 1"
+        },
+        {
+          href: "#active",
+          text: "Navigation item 2",
+        },
+        {
+          href: "/#",
+          text: "Navigation item 3"
+        }
+      ]}
+    />
+  </Story>
+</Preview>
+
+See when and how to show navigation links in the [Help users navigate a service pattern].
+
+
+[Help users to navigate a service pattern]: https://design-system.service.gov.uk/patterns/navigate-a-service/
+[GOV.UK header component]: /components?name=Header

--- a/components/service-navigation/spec/ServiceNavigation.ts
+++ b/components/service-navigation/spec/ServiceNavigation.ts
@@ -1,0 +1,89 @@
+import { createElement as h } from 'react';
+import { render, screen } from '@not-govuk/component-test-helpers';
+import ServiceNavigation from '../src/ServiceNavigation';
+
+describe('ServiceNavigation', () => {
+  const minimalProps = {
+  };
+
+  describe('when given minimal valid props', () => {
+    beforeEach(async () => {
+      render(h(ServiceNavigation, minimalProps));
+    });
+
+    it('renders an element', async () => expect(screen.getAllByRole('generic')[0]).toBeInTheDocument());
+  });
+
+  describe('when given just a service name and href', () => {
+    const props = {
+      ...minimalProps,
+      serviceName: 'My service',
+      serviceHref: '#href'
+    };
+
+    beforeEach(async () => {
+      render(h(ServiceNavigation, props));
+    });
+
+    it('renders a section', async () => expect(screen.getByRole('region')).toBeInTheDocument());
+    it('with a service link', async () => expect(screen.getAllByRole('link')[0]).toHaveTextContent('My service'));
+  });
+
+  describe('when given just some items', () => {
+    const props = {
+      ...minimalProps,
+      items: [
+        { href: '#', text: 'One' },
+        { href: '#', text: 'Two' },
+        { href: '#', text: 'Three' }
+      ]
+    };
+
+    beforeEach(async () => {
+      render(h(ServiceNavigation, props));
+    });
+
+    it('renders a navigation block', async () => expect(screen.getByRole('navigation')).toBeInTheDocument());
+    it('renders a list', async () => expect(screen.getByRole('list')).toBeInTheDocument());
+    it('with as many items as were provided', async () => expect(screen.getAllByRole('listitem')).toHaveLength(3));
+    it('which are all links', async () => expect(screen.getAllByRole('link')).toHaveLength(3));
+    it('with the correct text for the 1st link', async () => expect(screen.getAllByRole('link')[0]).toHaveTextContent('One'));
+    it('with the correct text for the 2nd link', async () => expect(screen.getAllByRole('link')[1]).toHaveTextContent('Two'));
+    it('with the correct text for the 3rd link', async () => expect(screen.getAllByRole('link')[2]).toHaveTextContent('Three'));
+  });
+
+  describe('when given all valid props', () => {
+    const props = {
+      ...minimalProps,
+      'aria-label': 'ARIA label',
+      end: 'End',
+      items: [
+        { href: '#', text: 'One' },
+        { href: '#', text: 'Two' },
+        { href: '#', text: 'Three' }
+      ],
+      menuButtonText: 'Menu text',
+      menuButtonLabel: 'Menu label',
+      navigationLabel: 'Navigation label',
+      navigationId: 'navigation-id',
+      serviceName: 'My service',
+      serviceHref: '#href',
+      start: 'Start'
+    };
+
+    beforeEach(async () => {
+      render(h(ServiceNavigation, props));
+    });
+
+    it('renders a section', async () => expect(screen.getByRole('region')).toBeInTheDocument());
+    it('with a service link', async () => expect(screen.getAllByRole('link')[0]).toHaveTextContent('My service'));
+    it('renders a navigation block', async () => expect(screen.getByRole('navigation')).toBeInTheDocument());
+    it('renders a list', async () => expect(screen.getByRole('list')).toBeInTheDocument());
+    it('with as many items as were provided', async () => expect(screen.getAllByRole('listitem')).toHaveLength(3));
+    it('which are all links', async () => expect(screen.getAllByRole('link')).toHaveLength(4));
+    it('with the correct text for the 1st link', async () => expect(screen.getAllByRole('link')[1]).toHaveTextContent('One'));
+    it('with the correct text for the 2nd link', async () => expect(screen.getAllByRole('link')[2]).toHaveTextContent('Two'));
+    it('with the correct text for the 3rd link', async () => expect(screen.getAllByRole('link')[3]).toHaveTextContent('Three'));
+    // FIXME: Test for remaining props
+  });
+});

--- a/components/service-navigation/src/ServiceNavigation.tsx
+++ b/components/service-navigation/src/ServiceNavigation.tsx
@@ -1,0 +1,97 @@
+import { FC, HTMLAttributes, ReactNode, createElement as h } from 'react';
+import { AnchorList } from '@not-govuk/anchor-list';
+import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
+import { A, LinkProps } from '@not-govuk/link';
+import { WidthContainer } from '@not-govuk/width-container';
+
+import '../assets/ServiceNavigation.scss';
+
+export type Anchor = LinkProps & {
+  /** Text of the link */
+  text: string
+};
+
+export type ServiceNavigationProps = StandardProps & HTMLAttributes<HTMLElement> & {
+  /** Elements to be injected at the end of the service header container */
+  end?: ReactNode
+  /** List of links to choose from */
+  items?: Anchor[]
+  /** The text of the mobile navigation menu toggle */
+  menuButtonText?: string
+  /** The screen reader label for the mobile navigation menu toggle */
+  menuButtonLabel?: string
+  /** The screen reader label for the mobile navigation menu. Defaults to the same value as menuButtonText if not specified. */
+  navigationLabel?: string
+  /** The ID used to associate the mobile navigation toggle with the navigation menu. */
+  navigationId?: string
+  /** Service link URL */
+  serviceHref?: string
+  /** Service link text */
+  serviceName?: string
+  /** Elements to be injected at the start of the service header container */
+  start?: ReactNode
+};
+
+export const ServiceNavigation: FC<ServiceNavigationProps> = ({
+  'aria-label': ariaLabel = 'Service information',
+  classBlock,
+  classModifiers,
+  className,
+  end = null,
+  items = [],
+  menuButtonText = 'Menu',
+  menuButtonLabel,
+  navigationLabel: _navigationLabel,
+  navigationId = 'navigation',
+  serviceHref,
+  serviceName,
+  start = null,
+  ...attrs
+}) => {
+  const classes = classBuilder('govuk-service-navigation', classBlock, classModifiers, className);
+  const navigationLabel = _navigationLabel || menuButtonText;
+
+  const serviceLink = !serviceName ? null : (
+    <span className={classes('service-name')}>
+      <A href={serviceHref} className={classes('link')}>
+        {serviceName}
+      </A>
+    </span>
+  );
+  const nav = !items.length ? null : (
+    <nav {...attrs} className={classes('wrapper')} aria-label={navigationLabel}>
+      <button type="button" className={classes('toggle', undefined, 'govuk-js-service-navigation-toggle')} aria-controls={navigationId} aria-label={menuButtonLabel} hidden>
+        {menuButtonText}
+      </button>
+      <AnchorList id={navigationId} classBlock={classes('list')} items={items} />
+    </nav>
+  );
+  const inner = (
+    <WidthContainer>
+      {start}
+      <div className={classes('container')}>
+        {serviceLink}
+        {nav}
+      </div>
+      {end}
+    </WidthContainer>
+  );
+
+  return (
+    serviceName
+      ? (
+        <section {...attrs} className={classes()} aria-label={ariaLabel} data-module="govuk-service_navigation" >
+          {inner}
+        </section>
+      )
+      : (
+        <div {...attrs} className={classes()} data-module="govuk-service_navigation" >
+          {inner}
+        </div>
+      )
+  );
+};
+
+ServiceNavigation.displayName = 'ServiceNavigation';
+
+export default ServiceNavigation;

--- a/components/service-navigation/tsconfig.json
+++ b/components/service-navigation/tsconfig.json
@@ -1,0 +1,1 @@
+../../lib/plop-pack/skel/component/tsconfig.json

--- a/lib-govuk/simple-components/package.json
+++ b/lib-govuk/simple-components/package.json
@@ -55,6 +55,7 @@
     "@not-govuk/sass-base": "workspace:^0.15.2",
     "@not-govuk/search-box": "workspace:^0.15.2",
     "@not-govuk/select": "workspace:^0.15.2",
+    "@not-govuk/service-navigation": "workspace:^0.15.2",
     "@not-govuk/skip-link": "workspace:^0.15.2",
     "@not-govuk/standalone-input": "workspace:^0.15.2",
     "@not-govuk/summary-card": "workspace:^0.15.2",

--- a/lib-govuk/simple-components/src/index.ts
+++ b/lib-govuk/simple-components/src/index.ts
@@ -26,6 +26,7 @@ export { default as PhaseBanner } from '@not-govuk/phase-banner';
 export { default as Radios } from '@not-govuk/radios';
 export { default as SearchBox } from '@not-govuk/search-box';
 export { default as Select } from '@not-govuk/select';
+export { default as ServiceNavigation } from '@not-govuk/service-navigation';
 export { default as SkipLink } from '@not-govuk/skip-link';
 export { default as StandaloneInput } from '@not-govuk/standalone-input';
 export { default as SummaryCard } from '@not-govuk/summary-card';

--- a/lib/client-renderer/src/index.ts
+++ b/lib/client-renderer/src/index.ts
@@ -59,11 +59,17 @@ export const hydrateOrRender: HydrateOrRender = ({
     user
   });
   const router = createBrowserRouter(routes, {
-    basename
+    basename,
+    future: {
+      v7_relativeSplatPath: true
+    }
   });
   const app = (
       h(RouterWrap, appProps,
         h(RouterProvider, {
+          future: {
+            v7_startTransition: true
+          },
           router,
           fallbackElement: h(LoadingPage, { ...appProps, routes: [] })
         }))

--- a/lib/component-test-helpers/src/index.ts
+++ b/lib/component-test-helpers/src/index.ts
@@ -15,6 +15,10 @@ const Providers: FC<{ children?: ReactNode, routerProps?: object }> = ({
 }) => (
   h(HelmetProvider, {},
     h(MemoryRouter, routerProps || {
+      future: {
+        v7_relativeSplatPath: true,
+        v7_startTransition: true
+      },
       initialEntries: ['/previous', '/current', '/next'],
       initialIndex: 1
     }, children) )

--- a/lib/server-renderer/src/index.ts
+++ b/lib/server-renderer/src/index.ts
@@ -191,7 +191,12 @@ export const reactRenderer: ReactRenderer = ({
       user: { ...user, accessToken: req.auth?.accessToken } // Add the access token separately, in order to keep it off the client
     });
     const basename = '/';
-    const { query, dataRoutes } = createStaticHandler(routes, { basename });
+    const { query, dataRoutes } = createStaticHandler(routes, {
+      basename,
+      future: {
+        v7_relativeSplatPath: true
+      }
+    });
 
     const nonce = res.nonce || '';
     const createApp = (router: Router, context: StaticHandlerContext) => (


### PR DESCRIPTION
Adds the new ServiceNavigation component from GDS.

Also:
- Deprecates the horizontal style for NavigationMenu (users should probably use the new ServiceNavigation component)
- Fixes some styling bugs on the SearchBox component
- Adds a 'secondary' to the SearchBox component for more subtle buttons
- Opts into some v7 react-router features that don't appear harmful (potentially BREAKING, but unlikely)