### PR TITLE
DateInput: Fix type of value props

### DIFF
--- a/components/date-input/spec/DateInput.ts
+++ b/components/date-input/spec/DateInput.ts
@@ -74,26 +74,4 @@ describe('DateInput', () => {
     it('has a month value', async () => expect(screen.getByLabelText('Month')).toHaveDisplayValue('12'));
     it('has a year value', async () => expect(screen.getByLabelText('Year')).toHaveDisplayValue('2024'));
   });
-
-  describe('when given a value prop', () => {
-    const props = {
-      ...minimalProps,
-      hint: 'The day you were born',
-      value: {
-        day: '06',
-        month: '12',
-        year: '2024'
-      },
-      onChange: jest.fn()
-    };
-    beforeEach(async () => {
-      render(h(DateInput, props));
-    });
-
-    it('renders a form-group', async () => expect(screen.getByRole('group')).toBeInTheDocument());
-    it('contains the label', async () => expect(screen.getByRole('group')).toHaveTextContent('My date'));
-    it('has a day value', async () => expect(screen.getByLabelText('Day')).toHaveDisplayValue('06'));
-    it('has a month value', async () => expect(screen.getByLabelText('Month')).toHaveDisplayValue('12'));
-    it('has a year value', async () => expect(screen.getByLabelText('Year')).toHaveDisplayValue('2024'));
-  });
 });

--- a/components/date-input/spec/DateInput.ts
+++ b/components/date-input/spec/DateInput.ts
@@ -31,4 +31,69 @@ describe('DateInput', () => {
     it('that is described by the error and the hint', async () => expect(screen.getByRole('group')).toHaveAccessibleDescription('The day you were born Error: Date must be in the past'));
     it('contains the label', async () => expect(screen.getByRole('group')).toHaveTextContent('My date'));
   });
+
+  describe('when given a defaultValue prop', () => {
+    const props = {
+      ...minimalProps,
+      hint: 'The day you were born',
+      defaultValue: {
+        day: '05',
+        month: '04',
+        year: '2025'
+      }
+    };
+    beforeEach(async () => {
+      render(h(DateInput, props));
+    });
+
+    it('renders a form-group', async () => expect(screen.getByRole('group')).toBeInTheDocument());
+    it('contains the label', async () => expect(screen.getByRole('group')).toHaveTextContent('My date'));
+    it('has a day value', async () => expect(screen.getByLabelText('Day')).toHaveDisplayValue('05'));
+    it('has a month value', async () => expect(screen.getByLabelText('Month')).toHaveDisplayValue('04'));
+    it('has a year value', async () => expect(screen.getByLabelText('Year')).toHaveDisplayValue('2025'));
+  });
+
+  describe('when given a value prop', () => {
+    const props = {
+      ...minimalProps,
+      hint: 'The day you were born',
+      value: {
+        day: '06',
+        month: '12',
+        year: '2024'
+      },
+      onChange: jest.fn()
+    };
+    beforeEach(async () => {
+      render(h(DateInput, props));
+    });
+
+    it('renders a form-group', async () => expect(screen.getByRole('group')).toBeInTheDocument());
+    it('contains the label', async () => expect(screen.getByRole('group')).toHaveTextContent('My date'));
+    it('has a day value', async () => expect(screen.getByLabelText('Day')).toHaveDisplayValue('06'));
+    it('has a month value', async () => expect(screen.getByLabelText('Month')).toHaveDisplayValue('12'));
+    it('has a year value', async () => expect(screen.getByLabelText('Year')).toHaveDisplayValue('2024'));
+  });
+
+  describe('when given a value prop', () => {
+    const props = {
+      ...minimalProps,
+      hint: 'The day you were born',
+      value: {
+        day: '06',
+        month: '12',
+        year: '2024'
+      },
+      onChange: jest.fn()
+    };
+    beforeEach(async () => {
+      render(h(DateInput, props));
+    });
+
+    it('renders a form-group', async () => expect(screen.getByRole('group')).toBeInTheDocument());
+    it('contains the label', async () => expect(screen.getByRole('group')).toHaveTextContent('My date'));
+    it('has a day value', async () => expect(screen.getByLabelText('Day')).toHaveDisplayValue('06'));
+    it('has a month value', async () => expect(screen.getByLabelText('Month')).toHaveDisplayValue('12'));
+    it('has a year value', async () => expect(screen.getByLabelText('Year')).toHaveDisplayValue('2024'));
+  });
 });

--- a/components/date-input/src/DateInput.tsx
+++ b/components/date-input/src/DateInput.tsx
@@ -28,7 +28,7 @@ export const isPreValidateError = (v: DateInputError): v is DateInputPreValidate
   )
 );
 
-export type DateInputProps = StandardProps & Omit<InputHTMLAttributes<HTMLInputElement>, 'label'> & {
+export type DateInputProps = StandardProps & Omit<InputHTMLAttributes<HTMLInputElement>, 'label' | 'value' | 'defaultValue'> & {
   /** Initial value of the field */
   defaultValue?: DateInputValue,
   /** Error message */


### PR DESCRIPTION
The `DateInput` component types for  the `value` and `defaultValue` prop expect to be both the default type for the `InputHTMLAttributes<HTMLInputElement>,` e.g. `string | string[] | undefined` but _ALSO_ a `DateInputValue` which expects an object of. `{ day: string, month: string, year: string }`

It is not possible for the value to be both a string and an object!

This fix allows the `value` and `defaultValue` to be set as a `DateInputValue` only by using `Omit` to exclude the default types from the `HTMLInputElement` type, in the same way that `label` was omitted.

This change allows the DateInput component to work properly with `react-hook-form` which passes the `value` into the component via the `register` function and `onChange` functions.


