### PR TITLE
More flexibity in captions for tables

### DIFF
--- a/components-internal/simple-table/src/SimpleTable.tsx
+++ b/components-internal/simple-table/src/SimpleTable.tsx
@@ -1,20 +1,37 @@
-import { FC, createElement as h } from 'react';
+import { ReactNode, FC, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 
 import '../assets/SimpleTable.scss';
 
 export type SimpleTableProps<T> = StandardProps & {
-  caption?: string
+  caption?: string | ReactNode
   data: T[]
   headings: T
   keys: (keyof T)[]
 };
 
-export const SimpleTable: FC<SimpleTableProps<any>> = ({ caption, classBlock, classModifiers, className, data, headings, keys, ...attrs }) => {
+export const SimpleTable: FC<SimpleTableProps<any>> = ({
+  caption: _caption,
+  classBlock,
+  classModifiers,
+  className,
+  data,
+  headings,
+  keys,
+  ...attrs
+}) => {
   const classes = classBuilder('penultimate-simple-table', classBlock, classModifiers, className);
+  const caption = (
+    typeof _caption !== 'string'
+      ? _caption
+      : _caption && (
+        <caption className={classes('caption')}>{_caption}</caption>
+      )
+  );
+
   return (
     <table {...attrs} className={classes()}>
-      {caption && (<caption className={classes('caption')}>{caption}</caption>)}
+      {caption}
       <thead className={classes('head')}>
         <tr className={classes('row')}>
           {keys.map((k, i) => (

--- a/components/table/spec/Table.stories.mdx
+++ b/components/table/spec/Table.stories.mdx
@@ -62,6 +62,35 @@ Never use the table component to layout content on a page. Instead, use the [gri
 
 Use the `<caption>` element to describe a table in the same way you would use a heading. A caption helps users find, navigate and understand tables.
 
+To use a custom caption, supply your element to the prop. (Supplying a string will receive standard styling with the `govuk-table__caption--m` class.)
+
+<Preview>
+  <Story name="Captions">
+    <Table
+      caption={<caption className="govuk-table__caption govuk-table__caption--l">Months and rates</caption>}
+      keys={['month', 'rate']}
+      headings={{
+        month: 'Month you apply',
+        rate: 'Rate for vehicles'
+      }}
+      data={[
+        {
+          month: 'January',
+          rate: '£95'
+        },
+        {
+          month: 'February',
+          rate: '£55'
+        },
+        {
+          month: 'March',
+          rate: '£125'
+        },
+      ]}
+    />
+  </Story>
+</Preview>
+
 
 ## Stories
 ### Standard

--- a/components/table/src/Table.tsx
+++ b/components/table/src/Table.tsx
@@ -1,13 +1,31 @@
 import { ComponentProps, FC, createElement as h } from 'react';
-import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
+import { classBuilder } from '@not-govuk/component-helpers';
 import { SimpleTable as _Table } from '@not-govuk/simple-table';
 
 import '../assets/Table.scss';
 
 export type TableProps = ComponentProps<typeof _Table>;
 
-export const Table: FC<TableProps> = ({ classBlock, ...props }) => (
-  <_Table {...props} classBlock={classBlock || 'govuk-table'} />
-);
+export const Table: FC<TableProps> = ({
+  classBlock: _classBlock,
+  classModifiers,
+  className,
+  caption: _caption,
+  ...props
+}) => {
+  const classBlock = _classBlock || 'govuk-table';
+  const classes = classBuilder('govuk-table', _classBlock, classModifiers, className);
+  const caption = (
+    typeof _caption !== 'string'
+      ? _caption
+      : (
+        <caption className={classes('caption', 'm')}>{_caption}</caption>
+      )
+  );
+
+  return (
+    <_Table {...props} classBlock={classBlock} classModifiers={classModifiers} className={className} caption={caption} />
+  );
+};
 
 export default Table;


### PR DESCRIPTION
Allows custom elements to be provided as captions for Table. Also sets the `--m` styling by default.

Fixes: #1364