### PR TITLE
fix: update Details so summary is wrapped in a `<span>` per GDS guidelines

### DIFF
--- a/components/details/src/Details.tsx
+++ b/components/details/src/Details.tsx
@@ -21,7 +21,11 @@ export const Details: FC<DetailsProps> = ({
 
   return (
     <details {...attrs} className={classes()}>
-      <summary className={classes('summary')}>{summary}</summary>
+      <summary className={classes('summary')}>
+        <span className={classes('summary-text')}>
+          {summary}
+        </span>
+      </summary>
       <div className={classes('text')}>
         {children}
       </div>


### PR DESCRIPTION
## Context

The current `<Details>` component does not align precisely to the current Government Design System markup: https://design-system.service.gov.uk/components/details/

The markup includes an additional `<span class="govuk-details__summary-text">....</span>` which has not been implemented in NotGovUK.

This has the effect of omitting the underline on the details summary heading

This PR fixes the inconsistency. 

No test was added for the inclusion of the wrapper, simply because Testing Library promotes not testing for specific DOM or. markup elements, and there is no precedent for that in the current test cases.