### PR TITLE
feat: Allow `ReactNode` for option labels on `Checkboxes` and `Radios` components

### DIFF
--- a/components/checkboxes/spec/Checkboxes.stories.mdx
+++ b/components/checkboxes/spec/Checkboxes.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
+import { Fragment } from 'react'
 import { TextInput } from '@not-govuk/text-input';
 import { Checkboxes } from '../src/Checkboxes';
 import readMe from '../README.md';
@@ -24,7 +25,7 @@ Let users select one or more options by using the checkboxes component.
       label={<h1 className="govuk-heading-l">Which types of waste do you transport?</h1>}
       name="waste"
       options={[
-        { value: 'carcasses', label: 'Waste from animal carcasses' },
+        { value: 'carcasses', label: <Fragment><b>Waste</b> from animal carcasses</Fragment> },
         { value: 'mines', label: 'Waste from mines or quarries' },
         { value: 'farm', label: 'Farm or agricultural waste' }
       ]}

--- a/components/checkboxes/spec/Checkboxes.ts
+++ b/components/checkboxes/spec/Checkboxes.ts
@@ -61,4 +61,26 @@ describe('Checkboxes', () => {
     it('renders the 3rd option\'s conditional', async () => expect(screen.getByRole('group')).toHaveTextContent('Conditional Three'));
     it.skip('renders the 3rd option\'s conditional as invisible', async () => expect(screen.getByText('Conditional Three')).not.toBeVisible());
   });
+
+  describe('when given a ReactNode as a label option', () => {
+    const props = {
+      label: 'Which types of waste do you transport?',
+      name: 'waste',
+      options: [
+        { value: 'carcasses', label: h('b', { children: 'Waste from animal carcasses' }), conditional: 'Conditional One' },
+        { value: 'mines', label: 'Waste from mines or quarries', conditional: 'Conditional Two', selected: true },
+        { value: 'farm', label: 'Farm or agricultural waste', conditional: 'Conditional Three' },
+        'or',
+        { value: 'abroad', label: 'None of the above', hint: 'I am NOT a waste carrier', exclusive: true }
+      ],
+      error: 'Select an option',
+      hint: 'Select all that apply.'
+    };
+
+    beforeEach(async () => {
+      render(h(Checkboxes, props));
+    });
+
+    it('renders the 1st option', async () => expect(screen.getByRole('group')).toHaveTextContent('Waste from animal carcasses'));
+  });
 });

--- a/components/checkboxes/src/Checkbox.tsx
+++ b/components/checkboxes/src/Checkbox.tsx
@@ -9,7 +9,7 @@ export type CheckboxProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'label'>
   classes: ClassBuilder
   conditional?: ReactNode
   hint?: string
-  label: string
+  label: string | ReactNode
 };
 
 export const Checkbox: FC<CheckboxProps> = ({

--- a/components/checkboxes/src/Checkbox.tsx
+++ b/components/checkboxes/src/Checkbox.tsx
@@ -9,7 +9,7 @@ export type CheckboxProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'label'>
   classes: ClassBuilder
   conditional?: ReactNode
   hint?: string
-  label: string | ReactNode
+  label: ReactNode
 };
 
 export const Checkbox: FC<CheckboxProps> = ({

--- a/components/checkboxes/src/Checkboxes.tsx
+++ b/components/checkboxes/src/Checkboxes.tsx
@@ -10,7 +10,7 @@ export type Option = {
   disabled?: boolean
   exclusive?: boolean
   hint?: string
-  label: string | ReactNode
+  label: ReactNode
   selected?: boolean
   value: string
 };

--- a/components/checkboxes/src/Checkboxes.tsx
+++ b/components/checkboxes/src/Checkboxes.tsx
@@ -10,7 +10,7 @@ export type Option = {
   disabled?: boolean
   exclusive?: boolean
   hint?: string
-  label: string
+  label: string | ReactNode
   selected?: boolean
   value: string
 };

--- a/components/radios/spec/Radios.stories.mdx
+++ b/components/radios/spec/Radios.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
+import { Fragment } from 'react'
 import { TextInput } from '@not-govuk/text-input';
 import { Radios } from '../src/Radios';
 import readMe from '../README.md';
@@ -25,7 +26,7 @@ import readMe from '../README.md';
         { value: 'england', label: 'England' },
         { value: 'scotland', label: 'Scotland' },
         { value: 'wales', label: 'Wales' },
-        { value: 'northern-ireland', label: 'Northern Ireland' }
+        { value: 'northern-ireland', label: <Fragment><b>Northern</b> Ireland</Fragment> }
       ]}
     />
   </Story>

--- a/components/radios/spec/Radios.ts
+++ b/components/radios/spec/Radios.ts
@@ -67,4 +67,26 @@ describe('Radios', () => {
     it('renders the 4th option\'s conditional', async () => expect(screen.getByRole('group')).toHaveTextContent('Conditional Four'));
     it.skip('renders the 4th option\'s conditional as invisible', async () => expect(screen.getByText('Conditional Four')).not.toBeVisible());
   });
+
+  describe('when given a ReactNode as a label option', () => {
+      const props = {
+        label: 'Which types of waste do you transport?',
+        name: 'waste',
+        options: [
+          { value: 'carcasses', label: h('b', { children: 'Waste from animal carcasses' }), conditional: 'Conditional One' },
+          { value: 'mines', label: 'Waste from mines or quarries', conditional: 'Conditional Two', selected: true },
+          { value: 'farm', label: 'Farm or agricultural waste', conditional: 'Conditional Three' },
+          'or',
+          { value: 'abroad', label: 'None of the above', hint: 'I am NOT a waste carrier', exclusive: true }
+        ],
+        error: 'Select an option',
+        hint: 'Select all that apply.'
+      };
+
+      beforeEach(async () => {
+        render(h(Radios, props));
+      });
+
+      it('renders the 1st option', async () => expect(screen.getByRole('group')).toHaveTextContent('Waste from animal carcasses'));
+    });
 });

--- a/components/radios/src/Radio.tsx
+++ b/components/radios/src/Radio.tsx
@@ -7,7 +7,7 @@ export type RadioProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'label'> & 
   classes: ClassBuilder
   conditional?: ReactNode
   hint?: string
-  label: string | ReactNode
+  label: ReactNode
 };
 
 export const Radio: FC<RadioProps> = ({

--- a/components/radios/src/Radio.tsx
+++ b/components/radios/src/Radio.tsx
@@ -7,7 +7,7 @@ export type RadioProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'label'> & 
   classes: ClassBuilder
   conditional?: ReactNode
   hint?: string
-  label: string
+  label: string | ReactNode
 };
 
 export const Radio: FC<RadioProps> = ({

--- a/components/radios/src/Radios.tsx
+++ b/components/radios/src/Radios.tsx
@@ -11,7 +11,7 @@ export type Option = {
   conditional?: ReactNode
   disabled?: boolean
   hint?: string
-  label: string | ReactNode
+  label: ReactNode
   selected?: boolean
   value: string
 };

--- a/components/radios/src/Radios.tsx
+++ b/components/radios/src/Radios.tsx
@@ -11,7 +11,7 @@ export type Option = {
   conditional?: ReactNode
   disabled?: boolean
   hint?: string
-  label: string
+  label: string | ReactNode
   selected?: boolean
   value: string
 };


### PR DESCRIPTION
## Context

Per HTML spec, radio button and checkbox labels should be allowed to accept an HTML DOM tree.
While the `Radio` and `Checkbox` components allow a ReactNode type for the `label` prop, the current implementation of the `Checkboxes` and `Radios` components does not.

This change permits the `ReactNode` type and this will continue to support the existing `string` type, since ReactNode can be a string.

