### PR TITLE
fix: add no-actions css class to the summary list items when one or more of the siblings have actions

### DIFF
--- a/components/summary-list/spec/SummaryList.ts
+++ b/components/summary-list/spec/SummaryList.ts
@@ -51,5 +51,43 @@ describe('SummaryList', () => {
     it('links to the href of the 1st action', async () => expect(screen.getAllByRole('link')[0]).toHaveAttribute('href', '/a'));
     it('links to the href of the 2nd action', async () => expect(screen.getAllByRole('link')[1]).toHaveAttribute('href', '/b'));
     it('links to the href of the 3rd action', async () => expect(screen.getAllByRole('link')[2]).toHaveAttribute('href', '/c'));
+    it('has the govuk-summary-list__row class on the first row', async () => {
+      const row = screen.getByText('Item A')
+      const container = row.parentElement
+      expect(container?.className).toBe('govuk-summary-list__row')
+    });
+  });
+
+  describe('when given some props with no actions', () => {
+    const props = {
+      ...minimalProps,
+      items: [
+        { name: 'Item A', children: 'One' },
+        { name: 'Item B', actions: [ { href: '/b', text: 'Change B' } ], children: 'Two' },
+        { name: 'Item C', actions: [ { href: '/c', text: 'Change C' } ], children: 'Three' },
+      ]
+    };
+
+    beforeEach(async () => {
+      render(h(SummaryList, props));
+    });
+
+    it('has the govuk-summary-list__row--no-actions class on the first row', async () => {
+      const row = screen.getByText('Item A')
+      const container = row.parentElement
+      expect(container?.className).toBe('govuk-summary-list__row govuk-summary-list__row--no-actions')
+    });
+
+    it('has the govuk-summary-list__row class only on the second row', async () => {
+      const row = screen.getByText('Item B')
+      const container = row.parentElement
+      expect(container?.className).toBe('govuk-summary-list__row')
+    });
+
+    it('has the govuk-summary-list__row class only on the third row', async () => {
+      const row = screen.getByText('Item C')
+      const container = row.parentElement
+      expect(container?.className).toBe('govuk-summary-list__row')
+    });
   });
 });

--- a/components/summary-list/src/SummaryList.tsx
+++ b/components/summary-list/src/SummaryList.tsx
@@ -11,14 +11,26 @@ export type SummaryListProps = SummaryListContainerProps & {
 
 const SummaryListComponent: FC<SummaryListProps> = ({
   classBlock = 'govuk-summary-list',
-  items,
+  items: _items,
   ...props
 }) => {
+  const items = _items.map(item => {
+    const hasActions = !!item.actions && (
+      !Array.isArray(item.actions) || item.actions.length > 0
+    );
+    return { item, hasActions };
+  });
+  const someActions = items.some(({ hasActions }) => hasActions);
+
   return (
     <SummaryListContainer {...props} classBlock={classBlock}>
-      {items.map((itemProps, i: number) => (
-        <SummaryListItem key={i}  {...itemProps} />
-      ))}
+      {items.map((itemProps, i: number) => {
+        // If some items have actions but this one doesn't, add the 'no-actions' modifier
+        // https://design-system.service.gov.uk/components/summary-list/#showing-rows-with-and-without-actions
+        const classModifiers = someActions && !itemProps.hasActions ? ['no-actions'] : [];
+
+        return <SummaryListItem key={i} {...itemProps.item} classModifiers={classModifiers} />
+      })}
     </SummaryListContainer>
   );
 };

--- a/components/summary-list/src/SummaryListItem.tsx
+++ b/components/summary-list/src/SummaryListItem.tsx
@@ -12,23 +12,27 @@ export type SummaryListItemProps = StandardProps & HTMLAttributes<HTMLDivElement
   children: ReactNode
   /** Actions available for the item */
   actions?: Action | Action[]
+  /** Indicates that one of the summary list items has actions */
+  noActions?: boolean
 };
 
 export const SummaryListItem: FC<SummaryListItemProps> = ({
   actions: _actions = [],
   children,
   classBlock,
-  classModifiers,
+  classModifiers = [],
   className,
   name,
   ...attrs
 }) => {
   const classes = classBuilder('govuk-summary-list', classBlock);
+
   const actions = (
     Array.isArray(_actions)
     ? _actions
     : [ _actions ]
   );
+
   const { children: firstActionChildren, text: firstActionText, ...firstActionProps } = actions[0] || {};
 
   return (


### PR DESCRIPTION
Implements: https://github.com/daniel-ac-martin/NotGovUK/issues/1513