### PR TITLE
Set body class in examples

### DIFF
--- a/apps/next-example/src/app/layout.tsx
+++ b/apps/next-example/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import React from "react";
 import { NotGovUKPage } from '@not-govuk/simple-components';
+import { AddBodyClass } from '../components/AddBodyClass';
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -19,6 +20,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
+        <AddBodyClass />
         <NotGovUKPage
           breadcrumbs={[
             {

--- a/apps/next-example/src/app/three/page.tsx
+++ b/apps/next-example/src/app/three/page.tsx
@@ -1,3 +1,5 @@
+import { Radios, TextInput } from '@not-govuk/simple-components';
+
 export default function Page() {
   return (
     <>
@@ -5,6 +7,63 @@ export default function Page() {
         Three
       </h1>
       <p>Three content</p>
+      <p>Here is a conditional radios example:</p>
+      <Radios
+        label={
+          <h1 className="govuk-heading-l">
+            How would you prefer to be contacted?
+          </h1>
+        }
+        name="how-contacted"
+        options={[
+          {
+            value: "email",
+            label: "Email",
+            conditional: (
+              <TextInput
+                autoComplete="email"
+                className="govuk-!-width-one-third"
+                id="contact-by-email"
+                label="Email address"
+                name="contact-by-email"
+                spellCheck={false}
+                type="email"
+              />
+            ),
+          },
+          {
+            value: "phone",
+            label: "Phone",
+            conditional: (
+              <TextInput
+                autoComplete="tel"
+                className="govuk-!-width-one-third"
+                id="contact-by-phone"
+                label="Phone number"
+                name="contact-by-phone"
+                spellCheck={false}
+                type="tel"
+              />
+            ),
+          },
+          {
+            value: "text message",
+            label: "Text message",
+            conditional: (
+              <TextInput
+                autoComplete="tel"
+                className="govuk-!-width-one-third"
+                id="contact-by-text"
+                label="Mobile phone number"
+                name="contact-by-text"
+                spellCheck={false}
+                type="tel"
+              />
+            ),
+          },
+        ]}
+        hint="Select one option."
+      />
     </>
   );
 }

--- a/apps/next-example/src/components/AddBodyClass.tsx
+++ b/apps/next-example/src/components/AddBodyClass.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export const AddBodyClass = () => {
+  useEffect(() => {
+    document.body.classList.add('js-enabled');
+  }, []);
+
+  return null;
+}
+
+export default AddBodyClass;

--- a/apps/remix-example/app/root.tsx
+++ b/apps/remix-example/app/root.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import {
   Links,
   Meta,
@@ -81,5 +82,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
+  useEffect(() => {
+    document.body.classList.add('js-enabled');
+  }, []);
+
   return <Outlet />;
 }

--- a/apps/remix-example/app/routes/three.tsx
+++ b/apps/remix-example/app/routes/three.tsx
@@ -1,4 +1,5 @@
 import type { MetaFunction } from "@remix-run/node";
+import { Radios, TextInput } from '@not-govuk/components';
 
 const title = "Three";
 
@@ -16,6 +17,63 @@ export default function Page() {
         {title}
       </h1>
       <p>{title} content</p>
+      <p>Here is a conditional radios example:</p>
+      <Radios
+        label={
+          <h1 className="govuk-heading-l">
+            How would you prefer to be contacted?
+          </h1>
+        }
+        name="how-contacted"
+        options={[
+          {
+            value: "email",
+            label: "Email",
+            conditional: (
+              <TextInput
+                autoComplete="email"
+                className="govuk-!-width-one-third"
+                id="contact-by-email"
+                label="Email address"
+                name="contact-by-email"
+                spellCheck={false}
+                type="email"
+              />
+            ),
+          },
+          {
+            value: "phone",
+            label: "Phone",
+            conditional: (
+              <TextInput
+                autoComplete="tel"
+                className="govuk-!-width-one-third"
+                id="contact-by-phone"
+                label="Phone number"
+                name="contact-by-phone"
+                spellCheck={false}
+                type="tel"
+              />
+            ),
+          },
+          {
+            value: "text message",
+            label: "Text message",
+            conditional: (
+              <TextInput
+                autoComplete="tel"
+                className="govuk-!-width-one-third"
+                id="contact-by-text"
+                label="Mobile phone number"
+                name="contact-by-text"
+                spellCheck={false}
+                type="tel"
+              />
+            ),
+          },
+        ]}
+        hint="Select one option."
+      />
     </>
   );
 }

--- a/docs/components.md
+++ b/docs/components.md
@@ -122,6 +122,8 @@ export default defineConfig({
 });
 ```
 
+You should ensure that you set the `js-enabled` class on an element that encompasses all of your components (such as your `<body` element or the Page component), when and only when client-side JavaScript executes. Otherwise some components will not render correctly.
+
 #### Limitations on Remix
 
 - You will need to manage your own `<head>` including the favicon.
@@ -164,6 +166,8 @@ const nextConfig = {
 
 export default nextConfig;
 ```
+
+You should ensure that you set the `js-enabled` class on an element that encompasses all of your components (such as your `<body` element or the Page component), when and only when client-side JavaScript executes. Otherwise some components will not render correctly.
 
 
 #### Pre-requisites on Next.js


### PR DESCRIPTION
Sets the `js-enabled` class on the `<body>` element when client-side JavaScript executes. This is in both the Next.js and Remix examples.

closes: #1551