### PR TITLE
sass-base: Deprecate webpack

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -181,6 +181,7 @@ const nextConfig = {
     plugins: [
       ...config.plugins,
       new webpack.NormalModuleReplacementPlugin(/^@react-foundry\/router$/, '@react-foundry\/router\/next'), // ADD THIS LINE
+      new webpack.NormalModuleReplacementPlugin(/^@not-govuk\/sass-base$/, '@not-govuk\/sass-base\/webpack'), // ADD THIS LINE; webpack requires tilde/~ prefixes on modules
     ]
   })
 };

--- a/lib/sass-base/package.json
+++ b/lib/sass-base/package.json
@@ -12,6 +12,9 @@
     },
     "./vite": {
       "sass": "./src/vite.scss"
+    },
+    "./webpack": {
+      "sass": "./src/webpack.scss"
     }
   },
   "files": [

--- a/lib/sass-base/src/index.scss
+++ b/lib/sass-base/src/index.scss
@@ -9,7 +9,7 @@ $govuk-text-colour: inherit;
 $govuk-link-active-colour: inherit;
 
 // Set the default asset path to be relative to the SCSS components
-$govuk-assets-path: '../../assets/' !default; // This default should probably change in the future
+$govuk-assets-path: '../../assets/' !default;
 
 // Enable new organisation colours
 $govuk-new-organisation-colours: true;
@@ -27,6 +27,6 @@ $not-govuk-dark-mode-border-colour: #000000;
   @extend .govuk-frontend-supported !optional;
 }
 
-// Webpack support; legacy convention
-$not-govuk-module-prefix: '~' !default;
+// Allow for Webpack to override this with legacy convention
+$not-govuk-module-prefix: '' !default;
 $govuk-assets-path-external: $not-govuk-module-prefix + 'govuk-frontend/dist/govuk/assets/';

--- a/lib/sass-base/src/webpack.scss
+++ b/lib/sass-base/src/webpack.scss
@@ -1,0 +1,7 @@
+// Set the asset path to be relative to the SCSS components
+$govuk-assets-path: '../../assets/';
+
+// Follow legacy convention
+$not-govuk-module-prefix: '~';
+
+@import "./index.scss";


### PR DESCRIPTION
... in favour of turbopack.

An override is now provided for webpack users, but this may be removed
in a future (major) version.