### PR TITLE
BREAKING: Drop support for Node.js v20

### DIFF
--- a/.github/workflows/change-assurance.yml
+++ b/.github/workflows/change-assurance.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '20', '22', '24' ]
+        node: [ '22', '24', '26' ]
     steps:
 
       - name: Check out repository


### PR DESCRIPTION
Removes Node.js v20 from the matrix build on unit tests.