### PR TITLE
react-router-example: Fix build for bad ESM imports

### DIFF
--- a/apps/react-router-example/vite.config.ts
+++ b/apps/react-router-example/vite.config.ts
@@ -23,5 +23,11 @@ export default defineConfig({
     alias: {
       '@not-govuk/sass-base': '@not-govuk/sass-base/vite' // Vite resolves url() differently from Turbo/webpack
     }
+  },
+  ssr: { // FIXME: Remove once Node.js ESM imports are fixed
+    noExternal: [
+      /^@not-govuk/,
+      /^@react-foundry/
+    ]
   }
 });

--- a/docs/components.md
+++ b/docs/components.md
@@ -116,6 +116,12 @@ export default defineConfig({
     alias: {
       '@not-govuk/sass-base': '@not-govuk/sass-base/vite' // Vite resolves url() differently from Turbopack
     }
+  },
+  ssr: {
+    noExternal: [
+      /^@not-govuk/,
+      /^@react-foundry/
+    ]
   }
   [...]
 });


### PR DESCRIPTION
We should remove this workaround once the problem is fixed.