### PR TITLE
PNPM: Don't delay react-foundry updates

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,8 @@ dedupePeerDependents: true          # Default
 resolutionMode: highest             # Default
 resolvePeersFromWorkspaceRoot: true # Default
 autoInstallPeers: false             # Needed to avoid build errors
+minimumReleaseAgeExclude:
+- '@react-foundry/*'
 onlyBuiltDependencies:
   - bun                             # Required in v10
   - cypress                         # Required in v10


### PR DESCRIPTION
This is useful because we control both sets of packages.