### PR TITLE
docs: Fix: Populate Props descriptions

### DIFF
--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -20,7 +20,12 @@ export default defineConfig({
     }
   },
   plugins: [
-    reactDocgenTypescript(),
+    reactDocgenTypescript({
+      compilerOptions: {},
+      include: [
+        '../../components/*/src/**/*.ts*'
+      ]
+    }),
     csf(),
     html(),
     mdx(),


### PR DESCRIPTION
This seems to have broken with the recent major update to Vite.